### PR TITLE
Add Linux Secret Service provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +203,15 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cfg-if"
@@ -400,12 +418,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus-crossroads"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64bff0bd181fba667660276c6b7ebdc50cff37ce593e7adf9e734f89c8f444e8"
+dependencies = [
+ "dbus",
+]
+
+[[package]]
 name = "dbus-secret-service"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
  "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
  "zeroize",
 ]
 
@@ -559,15 +594,22 @@ dependencies = [
 name = "factorseal"
 version = "0.1.0"
 dependencies = [
+ "aes",
  "argon2",
  "base64",
+ "cbc",
  "chacha20poly1305",
  "clap",
+ "dbus",
+ "dbus-crossroads",
+ "dbus-secret-service",
  "directories",
  "getrandom 0.3.4",
  "hardware-enclave",
  "hex",
+ "hkdf",
  "keyring-core",
+ "num-bigint",
  "rpassword",
  "serde",
  "serde_json",
@@ -813,6 +855,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -953,6 +996,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +1034,15 @@ dependencies = [
  "serde",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -995,6 +1071,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,21 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/factorseal/factorseal"
 
 [features]
-default = ["cli", "hardware", "keyring"]
+default = ["cli", "hardware", "keyring", "secret-service"]
 cli = ["dep:clap", "dep:directories", "dep:rpassword"]
 hardware = ["dep:hardware-enclave"]
 keyring = ["dep:keyring-core"]
 password = ["dep:argon2"]
+secret-service = [
+    "cli",
+    "hardware",
+    "dep:aes",
+    "dep:cbc",
+    "dep:dbus",
+    "dep:dbus-crossroads",
+    "dep:hkdf",
+    "dep:num-bigint",
+]
 yubikey = ["hardware", "dep:signature", "dep:yubikey"]
 
 [[bin]]
@@ -22,14 +32,18 @@ required-features = ["cli"]
 
 [dependencies]
 argon2 = { version = "0.5.3", optional = true }
+aes = { version = "0.8.4", optional = true }
 base64 = "0.22.1"
+cbc = { version = "0.1.2", features = ["alloc", "block-padding"], optional = true }
 chacha20poly1305 = "0.10.1"
 clap = { version = "4.5.41", features = ["derive", "env"], optional = true }
 directories = { version = "6.0.0", optional = true }
 getrandom = "0.3.3"
 hardware-enclave = { version = "0.2.10", default-features = false, features = ["encryption", "linux-tpm"], optional = true }
 hex = "0.4.3"
+hkdf = { version = "0.12.4", optional = true }
 keyring-core = { version = "1.0.0", optional = true }
+num-bigint = { version = "0.4.6", optional = true }
 rpassword = { version = "7.4.0", optional = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
@@ -39,6 +53,13 @@ tempfile = "3.20.0"
 thiserror = "2.0.12"
 yubikey = { version = "0.8.0", optional = true }
 zeroize = "1.8.1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+dbus = { version = "0.9.12", optional = true }
+dbus-crossroads = { version = "0.5.3", optional = true }
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+dbus-secret-service = { version = "4.1.0", features = ["crypto-rust"] }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -5,25 +5,235 @@
 > until its vault format and platform integrations have received independent
 > review.
 
-FactorSeal is a hardware-bound local keyring. It stores credentials by the
-same `service + account` identity used by keyring APIs:
+FactorSeal is a hardware-bound local keyring designed around mandatory,
+backup-ready multifactor unlock.
 
 ```text
-platform hardware [AND optional YubiKey]
-                  |
-          reconstruct one vault key
-                  |
-      get(service, account) -> secret
+platform hardware
+       AND
+any one enrolled authenticator
+       |
+reconstruct one vault key
+       |
+get(service, account) -> secret
 ```
 
-There are no recipients and no encrypted secret files in a project repository.
-Applications use the keyring API while the encrypted vault remains local to
-the machine.
+Every completed vault must have at least two independent authenticators
+enrolled. Only one is required for an ordinary unlock; the other exists so
+that losing a phone or security key does not permanently lock the user out.
 
-## Hardware support
+Examples of a valid enrollment are:
 
-The default `hardware` feature uses
-[`hardware-enclave`](https://docs.rs/hardware-enclave) for:
+- a primary YubiKey and a backup YubiKey;
+- a YubiKey and a phone;
+- two independently enrolled phones.
+
+The TPM or Secure Enclave is always required in addition to one enrolled
+authenticator. Two enrolled authenticators are alternatives, not two devices
+that must be presented together.
+
+## Implementation status
+
+This README describes the target design for FactorSeal's next vault format.
+The current version 2 prototype implements platform hardware with one optional
+YubiKey and can provide an unlocked vault through the Linux Secret Service
+D-Bus API. It does not yet enforce two enrolled authenticators, support phones
+or fingerprints, or implement atomic authenticator replacement.
+
+Until the new format is implemented, the commands and APIs in the repository
+retain their version 2 behavior. The target CLI examples below are a design
+contract, not yet available commands.
+
+## One identity, multiple authenticators
+
+A FactorSeal vault has one stable, random identity. Each phone or security key
+is a separate credential enrolled under that identity.
+
+```text
+vault 7c9e...
+  |
+  +-- YubiKey "primary"       factor 01
+  +-- iPhone "personal"       factor 02
+  +-- Android phone "backup"  factor 03
+```
+
+Authenticators never share or clone a private key. Each device has its own
+credential, label, provider metadata, and stable factor ID. A public-key
+fingerprint identifies the credential; a device serial number is only a hint
+for locating it.
+
+The unlock policy is:
+
+```text
+platform_required       = true
+authenticator_threshold = 1
+minimum_enrolled        = 2
+```
+
+These are separate rules. The threshold says that one authenticator can
+unlock. The minimum says that FactorSeal must maintain a backup.
+
+## Authenticator lifecycle
+
+### Initialize
+
+Initialization generates a random 256-bit vault key and enrolls two distinct
+authenticators in one uninterrupted ceremony. FactorSeal verifies that each
+authenticator can independently complete an unlock before activating the
+vault.
+
+The vault key must remain only in zeroizing process memory while enrollment is
+incomplete. FactorSeal must not write a temporary hardware-only wrapping that
+could later be restored to bypass multifactor unlock.
+
+The target flow is:
+
+```console
+factorseal init
+# Enroll primary authenticator
+# Enroll backup authenticator
+# Verify both, then activate the vault
+```
+
+### Unlock
+
+FactorSeal discovers the available enrolled authenticators and uses one
+selected device. It must not try PINs or biometric operations indiscriminately
+across devices.
+
+```text
+TPM / Secure Enclave + primary YubiKey  -> unlock
+TPM / Secure Enclave + backup phone     -> unlock
+TPM / Secure Enclave alone              -> reject
+YubiKey or phone alone                   -> reject
+```
+
+### Add
+
+An already unlocked vault may enroll additional authenticators:
+
+```console
+factorseal factor add yubikey --label "office key"
+factorseal factor add phone --label "personal phone"
+factorseal factor list
+```
+
+Enrollment requires proof of control of the new authenticator. FactorSeal
+rejects duplicate credential fingerprints.
+
+### Lose or replace
+
+If an authenticator is lost, the user unlocks with a remaining authenticator
+and performs an atomic replacement:
+
+```console
+factorseal factor replace <lost-factor-id>
+```
+
+Replacement must:
+
+1. Enroll and verify a new authenticator.
+2. Generate a new authenticator share and the corresponding platform share
+   for the unchanged vault key.
+3. Rewrap the platform share and protect the authenticator share for every
+   remaining authenticator.
+4. Remove the lost authenticator.
+5. Commit the new policy atomically.
+
+FactorSeal refuses an ordinary removal that would leave fewer than two
+enrolled authenticators. It never offers a command that downgrades a current
+vault to platform-hardware-only unlock.
+
+Restoring old policy metadata must not silently reactivate a revoked
+authenticator. The final format therefore needs authenticated policy metadata
+and rollback protection in addition to atomic filesystem updates.
+
+## Cryptographic composition
+
+FactorSeal extends its existing split-key construction to an authenticator
+group:
+
+```text
+vault key = platform share XOR authenticator share
+
+platform hardware wraps platform share
+
+authenticator A wraps authenticator share
+authenticator B wraps authenticator share
+authenticator C wraps authenticator share
+```
+
+Each independently protected envelope contains the same uniformly random
+authenticator share. Recovering any one envelope is sufficient, but it reveals
+nothing useful without the platform share.
+
+Adding an authenticator creates another envelope and does not rewrite stored
+credentials. Revoking one rotates both shares while preserving the vault key,
+so credential entries do not need to be rewritten and an old authenticator
+envelope cannot participate in the current unlock policy.
+
+XChaCha20-Poly1305 encrypts every credential independently with the reconstructed
+256-bit vault key. Credential service and account names are authenticated and
+hashed for their storage paths. An unlocked session retains only the zeroizing
+vault key, not a plaintext credential cache.
+
+## Authenticator providers
+
+All providers must preserve the split-key property. A provider must decrypt a
+wrapped share, perform key agreement, or produce a stable high-entropy secret.
+A simple yes/no approval is not sufficient.
+
+### YubiKey
+
+The current prototype uses a PIN-protected RSA-2048 PIV key in slot `9d`.
+The next format will treat each YubiKey as one member of the authenticator
+group rather than as a special single-device unlock method.
+
+Each YubiKey must have its own key and certificate. FactorSeal must not clone a
+PIV private key across backup devices.
+
+### Phones
+
+The planned phone provider uses a small companion application:
+
+- iOS generates a device-bound key in the Secure Enclave;
+- Android generates a non-exportable, preferably hardware-backed key in
+  Android Keystore;
+- Face ID, Touch ID, a strong biometric, or the device credential authorizes
+  each key use;
+- the desktop and phone pair through an authenticated QR ceremony;
+- the phone decrypts the authenticator share and returns it over a fresh,
+  transcript-bound encrypted session.
+
+The initial transport should work locally with a one-time QR code. Paired
+local-network or Bluetooth discovery can improve routine unlocks later. An
+optional end-to-end encrypted push relay may be added for remote approval, but
+the relay must never receive a vault key or factor share in plaintext.
+
+Phone credentials are device-bound by default. Restoring an application backup
+does not restore the private key; the user recovers through another enrolled
+authenticator.
+
+WebAuthn hybrid transport with the PRF extension is a possible future provider,
+subject to reliable cross-platform capability detection. Ordinary WebAuthn
+signatures alone are authorization assertions and cannot reconstruct a vault
+key share.
+
+### Recovery keys
+
+A high-entropy offline recovery key may be offered as an additional escape
+hatch. It does not count toward the two-authenticator enrollment minimum by
+default and must not be replaced with a password or short numeric code.
+
+TOTP is not an appropriate offline vault-key provider. Its short code cannot
+safely wrap a cryptographic share, and storing its verifier beside a local
+vault would not provide the intended hardware separation.
+
+## Platform hardware
+
+Every version 2 hardware vault, and every vault in the target format, requires
+a supported platform backend through
+[`hardware-enclave`](https://docs.rs/hardware-enclave):
 
 - macOS Secure Enclave;
 - Windows TPM 2.0;
@@ -34,63 +244,15 @@ FactorSeal fails closed when the package selects Windows DPAPI or the Linux
 software keyring fallback. A vault that records one hardware backend cannot be
 opened after silently switching to another.
 
-## How it works
+Multiple authenticators protect against losing an enrolled phone or security
+key. They do not recover a vault after losing or resetting its required TPM or
+Secure Enclave. Cross-machine access and platform recovery require a separate,
+explicitly designed policy.
 
-- Initialization generates a random 256-bit vault key.
-- Platform hardware protects that key using a vault-specific asymmetric key.
-- XChaCha20-Poly1305 encrypts every credential independently.
-- Credential service and account names are authenticated and hashed for their
-  storage paths.
-- An unlocked session retains only the zeroizing vault key, not decrypted
-  credential values.
-- Each `get` decrypts one requested value into a zeroizing buffer.
+## Credential storage and sessions
 
-With YubiKey two-factor unlock, FactorSeal splits the vault key into two random
-XOR shares. Platform hardware protects one share. A PIN-protected RSA-2048 PIV
-key in YubiKey slot `9d` derives the wrapping key for the other share. Both
-shares are required; neither factor protects a complete vault key.
-
-XChaCha20's 256-bit key provides a post-quantum margin for stored credential
-encryption. The current platform EC and YubiKey RSA wrapping operations are
-not post-quantum, because current TPM, Secure Enclave, and PIV interfaces do
-not expose suitable post-quantum primitives.
-
-## Quick start
-
-```console
-devenv shell
-cargo run -- init
-printf 'postgres://localhost/mydb' |
-  cargo run -- set my-project DATABASE_URL
-cargo run -- get my-project DATABASE_URL
-cargo run -- status
-```
-
-The default vault location is the platform-specific user-data directory.
-Override it with `--vault` or `FACTORSEAL_VAULT`.
-
-### YubiKey second factor
-
-Build with the non-default `yubikey` feature:
-
-```console
-cargo run --features yubikey -- init --yubikey
-cargo run --features yubikey -- add-yubikey
-cargo run --features yubikey -- remove-yubikey
-```
-
-The PIV key-management slot (`9d`) must already contain an RSA-2048 key and
-matching certificate. The device must expose PIV slot metadata (YubiKey
-firmware 5.2.3+). Its PIN policy must not be `Never`; configure a touch policy
-on the key if physical user presence is also required. FactorSeal never
-provisions or overwrites a PIV slot.
-
-The CLI prompts for the PIN without echo. `--yubikey-pin-file` and
-`FACTORSEAL_YUBIKEY_PIN_FILE` are intended for controlled non-interactive use.
-
-## Keyring API
-
-The default `keyring` feature exposes the primary application interface:
+Applications address credentials by the familiar `service + account`
+identity:
 
 ```rust
 use factorseal::{FactorSealStore, Vault};
@@ -105,50 +267,129 @@ let value = entry.get_password()?;
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-Use `Vault::unlock_with_yubikey` for a two-factor vault. The store keeps the
-vault key for its process lifetime but never keeps a plaintext credential
-cache.
+The example reflects the current API and will evolve to accept a generic
+authenticator session.
 
-## Password migration
+The target unlocked session holds one zeroizing vault key for a bounded
+lifetime. Every `get` decrypts only the requested credential into a zeroizing
+buffer. The planned desktop unlock agent will provide authorize-once behavior
+across processes without caching plaintext credential values.
 
-Password support is deliberately non-default:
+The agent must also provide:
+
+- explicit locking and session expiry;
+- application authorization;
+- audit events;
+- authenticator enrollment and replacement;
+- policy integrity and rollback detection.
+
+### Linux Secret Service provider
+
+On Linux, the current agent implements `org.freedesktop.secrets`, including
+plain and standard DH/AES sessions, the default collection, item search,
+creation, updates, deletion, locking, and prompts. This lets applications that
+already use libsecret, the Secret Service API, or a compatible language
+keyring use FactorSeal without application-specific integration.
+
+Run it in a terminal after stopping any other process that owns
+`org.freedesktop.secrets`:
+
+```console
+factorseal serve
+```
+
+The vault is fully unlocked once when the agent starts. That does not give
+every application vault-wide access. FactorSeal binds each cryptographic
+session to the caller's unique D-Bus connection and reports matching items as
+locked until the user approves them. Approval creates a grant for only that
+Linux process instance and item, keyed by PID plus process start time and
+cached for 15 minutes by default. A keyring library may reconnect during that
+period without prompting the same running application again:
+
+```console
+factorseal serve --approval-seconds 300
+```
+
+The first provider uses `/dev/tty` for approval, so it must run in the
+foreground. A desktop approval UI and fingerprint-backed confirmation are
+still required before installing it as a headless D-Bus-activated service.
+Closing a Secret Service session or calling `Lock` removes its grants; grants
+also expire automatically.
+
+Secret values remain in the existing FactorSeal entry files. Secret Service
+labels and searchable attributes are kept in a separately authenticated,
+encrypted index inside the vault. An existing CLI entry is imported into that
+index when an application searches for its exact `service + username`.
+
+## Current prototype quick start
+
+The existing version 2 CLI can still be exercised as follows:
+
+```console
+devenv shell
+cargo run -- init
+printf 'postgres://localhost/mydb' |
+  cargo run -- set my-project DATABASE_URL
+cargo run -- get my-project DATABASE_URL
+cargo run -- status
+```
+
+The default vault location is the platform-specific user-data directory.
+Override it with `--vault` or `FACTORSEAL_VAULT`.
+
+Current single-YubiKey support is behind the non-default `yubikey` feature:
+
+```console
+cargo run --features yubikey -- init --yubikey
+cargo run --features yubikey -- add-yubikey
+cargo run --features yubikey -- remove-yubikey
+```
+
+These commands are transitional and do not satisfy the target invariant that
+requires two enrolled authenticators.
+
+Password support is deliberately non-default and exists only for version 1
+migration and development:
 
 ```console
 cargo run --features password -- migrate-password
 ```
 
-The `password` feature can read and create version 1 password vaults for
-migration and development. It is not a fallback for version 2 hardware vaults.
-Migration only rewraps the vault key; credential entries are not decrypted or
-rewritten.
+A password is not an acceptable fallback for a current hardware-bound vault.
 
 ## Features
 
-- `hardware` (default): hardware-backed wrapping through `hardware-enclave`,
-  including native Linux TPM support.
-- `cli` (default): builds the `factorseal` command.
+- `hardware` (default): hardware-backed wrapping through `hardware-enclave`.
+- `cli` (default): builds the current `factorseal` command.
 - `keyring` (default): implements the `keyring-core` store and credential APIs.
-- `yubikey`: adds PIN-protected YubiKey PIV as an optional required factor.
-- `password`: enables legacy password vaults and hardware migration.
+- `secret-service` (Linux default): provides `org.freedesktop.secrets` with
+  caller-bound, item-specific approval grants.
+- `yubikey`: current version 2 single-YubiKey PIV support.
+- `password`: legacy version 1 password vaults and hardware migration.
 
-Minimal consumers can still build the credential-vault types without a
-provider:
+Minimal consumers can build the credential-vault types without a provider:
 
 ```console
 cargo build --no-default-features
 ```
 
 See [Architecture](docs/architecture.md),
-[Unlock providers](docs/providers.md), and [Security](SECURITY.md).
+[Unlock providers](docs/providers.md), and [Security](SECURITY.md). Those
+documents currently describe the implemented version 2 format and must be
+updated alongside the new format.
 
-## Roadmap
+## Security scope
 
-The main remaining component is a desktop unlock agent. It will authorize
-once, retain only the vault key for a bounded session, and serve keyring
-requests without caching plaintext credentials. Session expiry, explicit
-locking, application authorization, audit events, and recovery-key exports
-belong there.
+Hardware binding protects a copied vault from offline decryption. It cannot
+prevent an already-authorized application from reading and exfiltrating a
+credential returned to it.
 
-Existing applications only use FactorSeal automatically when their keyring
-library supports selecting this backend. System-wide Secret Service or native
-keychain bridges are separate platform integrations.
+The strength of an `any` authenticator group is bounded by its weakest enrolled
+provider. FactorSeal must communicate provider strength clearly and must not
+silently add passwords, short recovery codes, or approval-only mechanisms as
+equivalent alternatives to hardware-backed authenticators.
+
+Credential encryption has a post-quantum symmetric security margin, but the
+current platform EC and YubiKey RSA wrapping operations are not post-quantum.
+FactorSeal cannot offer end-to-end post-quantum hardware binding until the
+relevant hardware interfaces expose suitable primitives.

--- a/examples/linux_secret_service_smoke.rs
+++ b/examples/linux_secret_service_smoke.rs
@@ -1,0 +1,43 @@
+//! Manual interoperability check for a running `factorseal serve`.
+
+#[cfg(target_os = "linux")]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use std::collections::HashMap;
+
+    use dbus_secret_service::{EncryptionType, SecretService};
+
+    let service = SecretService::connect(EncryptionType::Dh)?;
+    let collection = service.get_default_collection()?;
+    let attributes = HashMap::from([
+        ("target", "default"),
+        ("service", "factorseal-smoke-test"),
+        ("username", "round-trip"),
+    ]);
+    let item = collection.create_item(
+        "FactorSeal interoperability check",
+        attributes.clone(),
+        b"secret-service-round-trip",
+        true,
+        "application/octet-stream",
+    )?;
+    drop(item);
+    drop(collection);
+    drop(service);
+
+    // Exercise the common keyring-library behavior of reconnecting for the
+    // next API call. The process-scoped grant should survive the reconnect.
+    let service = SecretService::connect(EncryptionType::Dh)?;
+    let mut result = service.search_items(attributes)?;
+    assert!(result.locked.is_empty());
+    assert_eq!(result.unlocked.len(), 1);
+    let item = result.unlocked.swap_remove(0);
+    assert_eq!(item.get_secret()?, b"secret-service-round-trip");
+    item.delete()?;
+    println!("FactorSeal Secret Service round trip succeeded");
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("this example requires Linux");
+}

--- a/src/bin/factorseal.rs
+++ b/src/bin/factorseal.rs
@@ -1,10 +1,14 @@
 use std::fs::{self, File};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
+#[cfg(all(target_os = "linux", feature = "secret-service"))]
+use std::time::Duration;
 
 use clap::{Parser, Subcommand};
 use directories::ProjectDirs;
 use factorseal::{Error as VaultError, UnlockedVault, Vault};
+#[cfg(all(target_os = "linux", feature = "secret-service"))]
+use factorseal::{SecretServiceError, SecretServiceOptions, serve_secret_service};
 use serde::Serialize;
 use zeroize::Zeroizing;
 
@@ -78,6 +82,14 @@ enum Command {
     /// Show non-secret vault metadata without unlocking.
     Status,
 
+    /// Provide FactorSeal through the Linux Secret Service D-Bus API.
+    #[cfg(all(target_os = "linux", feature = "secret-service"))]
+    Serve {
+        /// Seconds an application may reuse an approved, item-specific grant.
+        #[arg(long, default_value_t = 900, env = "FACTORSEAL_APPROVAL_SECONDS")]
+        approval_seconds: u64,
+    },
+
     /// Add a YubiKey as a required second factor.
     #[cfg(feature = "yubikey")]
     AddYubikey,
@@ -124,6 +136,10 @@ enum CliError {
 
     #[error("JSON serialization failed: {0}")]
     Json(#[from] serde_json::Error),
+
+    #[cfg(all(target_os = "linux", feature = "secret-service"))]
+    #[error(transparent)]
+    SecretService(#[from] SecretServiceError),
 
     #[error("refusing to read more than {maximum} bytes from `{path}`")]
     InputTooLarge { path: String, maximum: u64 },
@@ -198,20 +214,16 @@ fn run(cli: Cli) -> Result<(), CliError> {
             vault.delete(&service, &account)?;
             Ok(())
         }
-        Command::Status => {
-            let info = Vault::info(&vault_path)?;
-            let status = Status {
-                path: info.path.display().to_string(),
-                version: info.version,
-                vault_id: info.vault_id,
-                unlock_method: info.unlock_method,
-                hardware_backend: info.hardware_backend,
-                yubikey_serial: info.yubikey_serial,
-                state: "locked",
-            };
-            println!("{}", serde_json::to_string_pretty(&status)?);
-            Ok(())
-        }
+        Command::Status => show_status(&vault_path),
+        #[cfg(all(target_os = "linux", feature = "secret-service"))]
+        Command::Serve { approval_seconds } => serve_vault(
+            &vault_path,
+            approval_seconds,
+            #[cfg(feature = "password")]
+            cli.password_file.as_deref(),
+            #[cfg(feature = "yubikey")]
+            cli.yubikey_pin_file.as_deref(),
+        ),
         #[cfg(feature = "yubikey")]
         Command::AddYubikey => {
             let pin = read_yubikey_pin(cli.yubikey_pin_file.as_deref())?;
@@ -238,6 +250,45 @@ fn run(cli: Cli) -> Result<(), CliError> {
             Ok(())
         }
     }
+}
+
+fn show_status(path: &Path) -> Result<(), CliError> {
+    let info = Vault::info(path)?;
+    let status = Status {
+        path: info.path.display().to_string(),
+        version: info.version,
+        vault_id: info.vault_id,
+        unlock_method: info.unlock_method,
+        hardware_backend: info.hardware_backend,
+        yubikey_serial: info.yubikey_serial,
+        state: "locked",
+    };
+    println!("{}", serde_json::to_string_pretty(&status)?);
+    Ok(())
+}
+
+#[cfg(all(target_os = "linux", feature = "secret-service"))]
+fn serve_vault(
+    path: &Path,
+    approval_seconds: u64,
+    #[cfg(feature = "password")] password_file: Option<&Path>,
+    #[cfg(feature = "yubikey")] yubikey_pin_file: Option<&Path>,
+) -> Result<(), CliError> {
+    let vault = unlock_vault(
+        path,
+        #[cfg(feature = "password")]
+        password_file,
+        #[cfg(feature = "yubikey")]
+        yubikey_pin_file,
+    )?;
+    eprintln!("FactorSeal is providing org.freedesktop.secrets; approvals will appear here.");
+    serve_secret_service(
+        vault,
+        SecretServiceOptions {
+            approval_ttl: Duration::from_secs(approval_seconds),
+        },
+    )?;
+    Ok(())
 }
 
 fn resolve_vault_path(explicit: Option<PathBuf>) -> Result<PathBuf, CliError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,5 +19,11 @@ mod keyring;
 #[cfg(feature = "keyring")]
 pub use keyring::FactorSealStore;
 
+#[cfg(all(target_os = "linux", feature = "secret-service"))]
+mod secret_service;
+
+#[cfg(all(target_os = "linux", feature = "secret-service"))]
+pub use secret_service::{SecretServiceError, SecretServiceOptions, serve_secret_service};
+
 #[cfg(feature = "yubikey")]
 mod yubikey_factor;

--- a/src/secret_service.rs
+++ b/src/secret_service.rs
@@ -1,0 +1,1851 @@
+//! Linux Secret Service provider backed by an unlocked FactorSeal vault.
+
+use std::collections::HashMap;
+use std::fs::OpenOptions;
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, mpsc};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use aes::cipher::block_padding::Pkcs7;
+use aes::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit};
+use dbus::arg::{PropMap, RefArg, Variant, prop_cast};
+use dbus::blocking::SyncConnection;
+use dbus::channel::{MatchingReceiver, Sender};
+use dbus::strings::{Interface, Member};
+use dbus::{Message, Path};
+use dbus_crossroads::{Context, Crossroads, IfaceToken, MethodErr, PropContext};
+use hkdf::Hkdf;
+use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use zeroize::Zeroizing;
+
+use crate::{Error as VaultError, UnlockedVault};
+
+const BUS_NAME: &str = "org.freedesktop.secrets";
+const SERVICE_PATH: &str = "/org/freedesktop/secrets";
+const COLLECTION_PATH: &str = "/org/freedesktop/secrets/collection/factorseal";
+const DEFAULT_ALIAS_PATH: &str = "/org/freedesktop/secrets/aliases/default";
+const SESSION_PREFIX: &str = "/org/freedesktop/secrets/session/s";
+const PROMPT_PREFIX: &str = "/org/freedesktop/secrets/prompt/p";
+const ITEM_PREFIX: &str = "/org/freedesktop/secrets/collection/factorseal/";
+const ROOT_PATH: &str = "/";
+const COLLECTION_RESOURCE: &str = "*";
+const INDEX_FORMAT: &str = "factorseal-secret-service-metadata";
+const INDEX_VERSION: u32 = 1;
+const ITEM_LABEL: &str = "org.freedesktop.Secret.Item.Label";
+const ITEM_ATTRIBUTES: &str = "org.freedesktop.Secret.Item.Attributes";
+const COLLECTION_LABEL: &str = "org.freedesktop.Secret.Collection.Label";
+const ALGORITHM_PLAIN: &str = "plain";
+const ALGORITHM_DH: &str = "dh-ietf1024-sha256-aes128-cbc-pkcs7";
+const AES_KEY_BYTES: usize = 16;
+const AES_BLOCK_BYTES: usize = 16;
+const DH_BYTES: usize = 128;
+const DH_PRIME_BYTES: [u8; DH_BYTES] = [
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xC9, 0x0F, 0xDA, 0xA2, 0x21, 0x68, 0xC2, 0x34,
+    0xC4, 0xC6, 0x62, 0x8B, 0x80, 0xDC, 0x1C, 0xD1, 0x29, 0x02, 0x4E, 0x08, 0x8A, 0x67, 0xCC, 0x74,
+    0x02, 0x0B, 0xBE, 0xA6, 0x3B, 0x13, 0x9B, 0x22, 0x51, 0x4A, 0x08, 0x79, 0x8E, 0x34, 0x04, 0xDD,
+    0xEF, 0x95, 0x19, 0xB3, 0xCD, 0x3A, 0x43, 0x1B, 0x30, 0x2B, 0x0A, 0x6D, 0xF2, 0x5F, 0x14, 0x37,
+    0x4F, 0xE1, 0x35, 0x6D, 0x6D, 0x51, 0xC2, 0x45, 0xE4, 0x85, 0xB5, 0x76, 0x62, 0x5E, 0x7E, 0xC6,
+    0xF4, 0x4C, 0x42, 0xE9, 0xA6, 0x37, 0xED, 0x6B, 0x0B, 0xFF, 0x5C, 0xB6, 0xF4, 0x06, 0xB7, 0xED,
+    0xEE, 0x38, 0x6B, 0xFB, 0x5A, 0x89, 0x9F, 0xA5, 0xAE, 0x9F, 0x24, 0x11, 0x7C, 0x4B, 0x1F, 0xE6,
+    0x49, 0x28, 0x66, 0x51, 0xEC, 0xE6, 0x53, 0x81, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+];
+
+type Secret = (Path<'static>, Vec<u8>, Vec<u8>, String);
+type DynVariant = Variant<Box<dyn RefArg + 'static>>;
+
+/// Runtime settings for the Linux Secret Service provider.
+#[derive(Clone, Debug)]
+pub struct SecretServiceOptions {
+    /// How long an approved application may reuse an item-specific grant.
+    pub approval_ttl: Duration,
+}
+
+impl Default for SecretServiceOptions {
+    fn default() -> Self {
+        Self {
+            approval_ttl: Duration::from_secs(15 * 60),
+        }
+    }
+}
+
+/// Errors returned while starting or running the Linux Secret Service provider.
+#[derive(Debug, thiserror::Error)]
+pub enum SecretServiceError {
+    #[error(transparent)]
+    Vault(#[from] VaultError),
+
+    #[error("D-Bus error: {0}")]
+    Dbus(#[from] dbus::Error),
+
+    #[error("another process already owns org.freedesktop.secrets")]
+    NameAlreadyOwned,
+
+    #[error("Secret Service state lock was poisoned")]
+    Poisoned,
+
+    #[error("Secret Service index is malformed: {0}")]
+    InvalidIndex(String),
+}
+
+/// Serve the standard Linux Secret Service API until the process is stopped.
+///
+/// The caller must unlock the vault before starting the provider. Secret
+/// Service sessions and grants are still scoped to each application's unique
+/// D-Bus connection.
+pub fn serve_secret_service(
+    vault: UnlockedVault,
+    options: SecretServiceOptions,
+) -> Result<(), SecretServiceError> {
+    use dbus::blocking::stdintf::org_freedesktop_dbus::RequestNameReply;
+
+    let connection = Arc::new(SyncConnection::new_session()?);
+    let reply = connection.request_name(BUS_NAME, false, false, true)?;
+    if !matches!(
+        reply,
+        RequestNameReply::PrimaryOwner | RequestNameReply::AlreadyOwner
+    ) {
+        return Err(SecretServiceError::NameAlreadyOwned);
+    }
+
+    let (approval_sender, approval_receiver) = mpsc::channel();
+    let agent = Arc::new(Agent::new(vault, options, approval_sender)?);
+    let mut crossroads = Crossroads::new();
+    let interfaces = register_interfaces(&mut crossroads);
+
+    crossroads.insert(
+        SERVICE_PATH,
+        &[interfaces.service],
+        ServiceObject(Arc::clone(&agent)),
+    );
+    crossroads.insert(
+        COLLECTION_PATH,
+        &[interfaces.collection],
+        CollectionObject(Arc::clone(&agent)),
+    );
+    crossroads.insert(
+        DEFAULT_ALIAS_PATH,
+        &[interfaces.collection],
+        CollectionObject(Arc::clone(&agent)),
+    );
+    for id in agent.item_ids()? {
+        crossroads.insert(
+            item_path(&id),
+            &[interfaces.item],
+            ItemObject {
+                agent: Arc::clone(&agent),
+                id,
+            },
+        );
+    }
+
+    let crossroads = Arc::new(Mutex::new(crossroads));
+    let disconnect_agent = Arc::clone(&agent);
+    connection.add_match(
+        dbus::message::MatchRule::new_signal("org.freedesktop.DBus", "NameOwnerChanged"),
+        move |(name, old_owner, new_owner): (String, String, String), _, _| {
+            if name.starts_with(':') && !old_owner.is_empty() && new_owner.is_empty() {
+                disconnect_agent.disconnect_owner(&name);
+            }
+            true
+        },
+    )?;
+    let handler = Arc::clone(&crossroads);
+    connection.start_receive(
+        dbus::message::MatchRule::new_method_call(),
+        Box::new(move |message, connection| {
+            if let Ok(mut crossroads) = handler.lock() {
+                let _ = crossroads.handle_message(message, connection);
+            }
+            true
+        }),
+    );
+
+    loop {
+        connection.process(Duration::from_millis(100))?;
+        while let Ok(event) = approval_receiver.try_recv() {
+            let completion = match agent.complete_prompt(event) {
+                Ok(Some(completion)) => completion,
+                Ok(None) => continue,
+                Err(error) => {
+                    eprintln!(
+                        "factorseal: approval action for prompt {} failed: {error}",
+                        event.prompt_id
+                    );
+                    PromptCompletion::dismissed(event.prompt_id)
+                }
+            };
+            if let Some(item) = &completion.created {
+                lock(&crossroads)?.insert(
+                    item_path(&item.id),
+                    &[interfaces.item],
+                    ItemObject {
+                        agent: Arc::clone(&agent),
+                        id: item.id.clone(),
+                    },
+                );
+                connection
+                    .send(collection_signal("ItemCreated", item_path(&item.id)))
+                    .map_err(|()| dbus::Error::new_failed("failed to send ItemCreated"))?;
+            }
+            if let Some(id) = &completion.deleted {
+                let _ = lock(&crossroads)?.remove::<ItemObject>(&item_path(id));
+                connection
+                    .send(collection_signal("ItemDeleted", item_path(id)))
+                    .map_err(|()| dbus::Error::new_failed("failed to send ItemDeleted"))?;
+            }
+            connection
+                .send(completion.message())
+                .map_err(|()| dbus::Error::new_failed("failed to send prompt completion"))?;
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ServiceObject(Arc<Agent>);
+
+#[derive(Clone)]
+struct CollectionObject(Arc<Agent>);
+
+struct ItemObject {
+    agent: Arc<Agent>,
+    id: String,
+}
+
+struct SessionObject {
+    agent: Arc<Agent>,
+    owner: String,
+}
+
+struct PromptObject {
+    agent: Arc<Agent>,
+    id: u64,
+    owner: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Index {
+    format: String,
+    version: u32,
+    items: Vec<IndexItem>,
+}
+
+impl Default for Index {
+    fn default() -> Self {
+        Self {
+            format: INDEX_FORMAT.to_owned(),
+            version: INDEX_VERSION,
+            items: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct IndexItem {
+    id: String,
+    service: String,
+    account: String,
+    label: String,
+    attributes: HashMap<String, String>,
+    content_type: String,
+    item_type: String,
+    created: u64,
+    modified: u64,
+}
+
+struct Agent {
+    vault: Arc<UnlockedVault>,
+    index: Mutex<Index>,
+    sessions: Mutex<HashMap<String, Session>>,
+    grants: Mutex<HashMap<(String, String), Instant>>,
+    prompts: Mutex<HashMap<u64, PendingPrompt>>,
+    identities: Mutex<HashMap<String, CallerIdentity>>,
+    next_id: AtomicU64,
+    options: SecretServiceOptions,
+    approval_sender: mpsc::Sender<ApprovalEvent>,
+    approval_gate: Mutex<()>,
+}
+
+#[derive(Clone)]
+struct Session {
+    owner: String,
+    cipher: SessionCipher,
+}
+
+#[derive(Clone)]
+enum SessionCipher {
+    Plain,
+    Dh(Zeroizing<[u8; AES_KEY_BYTES]>),
+}
+
+#[derive(Clone, Debug)]
+struct CallerIdentity {
+    bus_name: String,
+    process_id: Option<u32>,
+    executable: Option<PathBuf>,
+    grant_subject: String,
+}
+
+struct PendingPrompt {
+    owner: String,
+    action: PromptAction,
+    started: bool,
+}
+
+enum PromptAction {
+    Unlock {
+        objects: Vec<PromptObjectRef>,
+    },
+    Create {
+        item: Box<IndexItem>,
+        secret: Zeroizing<Vec<u8>>,
+    },
+    Delete {
+        id: String,
+    },
+}
+
+enum PromptObjectRef {
+    Collection,
+    Item(String),
+}
+
+#[derive(Clone, Copy)]
+struct ApprovalEvent {
+    prompt_id: u64,
+    approved: bool,
+}
+
+enum CompletionResult {
+    Paths(Vec<Path<'static>>),
+    Path(Path<'static>),
+    Empty,
+}
+
+struct PromptCompletion {
+    prompt_id: u64,
+    dismissed: bool,
+    result: CompletionResult,
+    created: Option<IndexItem>,
+    deleted: Option<String>,
+}
+
+impl PromptCompletion {
+    fn dismissed(prompt_id: u64) -> Self {
+        Self {
+            prompt_id,
+            dismissed: true,
+            result: CompletionResult::Empty,
+            created: None,
+            deleted: None,
+        }
+    }
+
+    fn message(self) -> Message {
+        let path = prompt_path(self.prompt_id);
+        let interface = Interface::new("org.freedesktop.Secret.Prompt").expect("valid interface");
+        let member = Member::new("Completed").expect("valid signal member");
+        let message = Message::signal(&path, &interface, &member);
+        if self.dismissed {
+            return message.append2(true, Variant(String::new()));
+        }
+        match self.result {
+            CompletionResult::Paths(paths) => message.append2(false, Variant(paths)),
+            CompletionResult::Path(path) => message.append2(false, Variant(path)),
+            CompletionResult::Empty => message.append2(false, Variant(String::new())),
+        }
+    }
+}
+
+impl Agent {
+    fn new(
+        vault: UnlockedVault,
+        options: SecretServiceOptions,
+        approval_sender: mpsc::Sender<ApprovalEvent>,
+    ) -> Result<Self, SecretServiceError> {
+        let vault = Arc::new(vault);
+        let index = match vault.read_secret_service_index()? {
+            Some(bytes) => {
+                let parsed: Index = serde_json::from_slice(&bytes)
+                    .map_err(|error| SecretServiceError::InvalidIndex(error.to_string()))?;
+                if parsed.format != INDEX_FORMAT || parsed.version != INDEX_VERSION {
+                    return Err(SecretServiceError::InvalidIndex(
+                        "unsupported format or version".to_owned(),
+                    ));
+                }
+                parsed
+            }
+            None => Index::default(),
+        };
+        Ok(Self {
+            vault,
+            index: Mutex::new(index),
+            sessions: Mutex::new(HashMap::new()),
+            grants: Mutex::new(HashMap::new()),
+            prompts: Mutex::new(HashMap::new()),
+            identities: Mutex::new(HashMap::new()),
+            next_id: AtomicU64::new(1),
+            options,
+            approval_sender,
+            approval_gate: Mutex::new(()),
+        })
+    }
+
+    fn item_ids(&self) -> Result<Vec<String>, SecretServiceError> {
+        Ok(lock(&self.index)?
+            .items
+            .iter()
+            .map(|item| item.id.clone())
+            .collect())
+    }
+
+    fn remember_identity(&self, owner: &str) {
+        let identity = resolve_caller_identity(owner);
+        if let Ok(mut identities) = self.identities.lock() {
+            identities.insert(owner.to_owned(), identity);
+        }
+    }
+
+    fn open_session(&self, owner: &str, cipher: SessionCipher) -> Result<Path<'static>, MethodErr> {
+        self.remember_identity(owner);
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let path = format!("{SESSION_PREFIX}{id}");
+        lock_method(&self.sessions)?.insert(
+            path.clone(),
+            Session {
+                owner: owner.to_owned(),
+                cipher,
+            },
+        );
+        dbus_path(&path)
+    }
+
+    fn close_session(&self, path: &Path<'_>, owner: &str) -> Result<(), MethodErr> {
+        let mut sessions = lock_method(&self.sessions)?;
+        let path_key = path.to_string();
+        let session = sessions.get(&path_key).ok_or_else(|| no_session(path))?;
+        ensure_owner(&session.owner, owner)?;
+        sessions.remove(&path_key);
+        self.remove_owner_grants(owner)?;
+        Ok(())
+    }
+
+    fn decrypt_secret(
+        &self,
+        secret: &Secret,
+        owner: &str,
+    ) -> Result<Zeroizing<Vec<u8>>, MethodErr> {
+        let sessions = lock_method(&self.sessions)?;
+        let path_key = secret.0.to_string();
+        let session = sessions
+            .get(&path_key)
+            .ok_or_else(|| no_session(&secret.0))?;
+        ensure_owner(&session.owner, owner)?;
+        match &session.cipher {
+            SessionCipher::Plain => {
+                if !secret.1.is_empty() {
+                    return Err(MethodErr::invalid_arg(&"plain session parameters"));
+                }
+                Ok(Zeroizing::new(secret.2.clone()))
+            }
+            SessionCipher::Dh(key) => {
+                if secret.1.len() != AES_BLOCK_BYTES {
+                    return Err(MethodErr::invalid_arg(&"AES initialization vector"));
+                }
+                let plaintext = cbc::Decryptor::<aes::Aes128>::new(
+                    key.as_ref().into(),
+                    secret.1.as_slice().into(),
+                )
+                .decrypt_padded_vec_mut::<Pkcs7>(&secret.2)
+                .map_err(|_| MethodErr::invalid_arg(&"encrypted Secret payload"))?;
+                Ok(Zeroizing::new(plaintext))
+            }
+        }
+    }
+
+    fn encrypt_secret(
+        &self,
+        session_path: &Path<'static>,
+        owner: &str,
+        plaintext: &[u8],
+        content_type: String,
+    ) -> Result<Secret, MethodErr> {
+        let sessions = lock_method(&self.sessions)?;
+        let path_key = session_path.to_string();
+        let session = sessions
+            .get(&path_key)
+            .ok_or_else(|| no_session(session_path))?;
+        ensure_owner(&session.owner, owner)?;
+        match &session.cipher {
+            SessionCipher::Plain => Ok((
+                session_path.clone(),
+                Vec::new(),
+                plaintext.to_vec(),
+                content_type,
+            )),
+            SessionCipher::Dh(key) => {
+                let mut iv = [0_u8; AES_BLOCK_BYTES];
+                getrandom::fill(&mut iv).map_err(|error| MethodErr::failed(&error))?;
+                let ciphertext =
+                    cbc::Encryptor::<aes::Aes128>::new(key.as_ref().into(), (&iv).into())
+                        .encrypt_padded_vec_mut::<Pkcs7>(plaintext);
+                Ok((session_path.clone(), iv.to_vec(), ciphertext, content_type))
+            }
+        }
+    }
+
+    fn search(&self, attributes: &HashMap<String, String>) -> Result<Vec<IndexItem>, MethodErr> {
+        let mut index = lock_method(&self.index)?;
+        let mut matches: Vec<_> = index
+            .items
+            .iter()
+            .filter(|item| attributes_match(&item.attributes, attributes))
+            .cloned()
+            .collect();
+        if matches.is_empty() {
+            if let (Some(service), Some(account)) = (
+                attributes.get("service"),
+                attributes
+                    .get("username")
+                    .or_else(|| attributes.get("account")),
+            ) {
+                if self
+                    .vault
+                    .contains(service, account)
+                    .map_err(vault_method)?
+                {
+                    let now = unix_time();
+                    let item = IndexItem {
+                        id: random_id().map_err(vault_method)?,
+                        service: service.clone(),
+                        account: account.clone(),
+                        label: format!("{service}: {account}"),
+                        attributes: attributes.clone(),
+                        content_type: "application/octet-stream".to_owned(),
+                        item_type: "org.freedesktop.Secret.Generic".to_owned(),
+                        created: now,
+                        modified: now,
+                    };
+                    index.items.push(item.clone());
+                    self.save_index(&index)?;
+                    matches.push(item);
+                }
+            }
+        }
+        Ok(matches)
+    }
+
+    fn item(&self, id: &str) -> Result<IndexItem, MethodErr> {
+        lock_method(&self.index)?
+            .items
+            .iter()
+            .find(|item| item.id == id)
+            .cloned()
+            .ok_or_else(|| no_item(id))
+    }
+
+    fn all_items(&self) -> Result<Vec<IndexItem>, MethodErr> {
+        Ok(lock_method(&self.index)?.items.clone())
+    }
+
+    fn save_index(&self, index: &Index) -> Result<(), MethodErr> {
+        let bytes = serde_json::to_vec(index).map_err(|error| MethodErr::failed(&error))?;
+        self.vault
+            .write_secret_service_index(&bytes)
+            .map_err(vault_method)
+    }
+
+    fn set_item_secret(
+        &self,
+        id: &str,
+        plaintext: &[u8],
+        content_type: String,
+    ) -> Result<(), MethodErr> {
+        let mut index = lock_method(&self.index)?;
+        let mut updated = index.clone();
+        let item = updated
+            .items
+            .iter_mut()
+            .find(|item| item.id == id)
+            .ok_or_else(|| no_item(id))?;
+        let previous = self
+            .vault
+            .get(&item.service, &item.account)
+            .map_err(vault_method)?;
+        let service = item.service.clone();
+        let account = item.account.clone();
+        item.content_type = content_type;
+        item.modified = unix_time();
+        let bytes = serde_json::to_vec(&updated).map_err(|error| MethodErr::failed(&error))?;
+
+        self.vault
+            .set(&service, &account, plaintext)
+            .map_err(vault_method)?;
+        if let Err(error) = self.vault.write_secret_service_index(&bytes) {
+            let rollback = self.vault.set(&service, &account, &previous);
+            return Err(transaction_error(&error, rollback.as_ref().err()));
+        }
+        *index = updated;
+        Ok(())
+    }
+
+    fn has_grant(&self, owner: &str, resource: &str) -> Result<bool, MethodErr> {
+        let now = Instant::now();
+        let subject = self.grant_subject(owner)?;
+        let mut grants = lock_method(&self.grants)?;
+        grants.retain(|_, expires| *expires > now);
+        Ok(grants.contains_key(&(subject.clone(), resource.to_owned()))
+            || grants.contains_key(&(subject, COLLECTION_RESOURCE.to_owned())))
+    }
+
+    fn grant(&self, owner: &str, resource: &str) -> Result<(), MethodErr> {
+        let now = Instant::now();
+        let subject = self.grant_subject(owner)?;
+        let expires = now
+            .checked_add(self.options.approval_ttl)
+            .ok_or_else(|| MethodErr::failed(&"approval duration is too large"))?;
+        lock_method(&self.grants)?.insert((subject, resource.to_owned()), expires);
+        Ok(())
+    }
+
+    fn remove_owner_grants(&self, owner: &str) -> Result<(), MethodErr> {
+        let subject = self.grant_subject(owner)?;
+        lock_method(&self.grants)?.retain(|(grant_subject, _), _| grant_subject != &subject);
+        Ok(())
+    }
+
+    fn disconnect_owner(&self, owner: &str) {
+        if let Ok(mut sessions) = self.sessions.lock() {
+            sessions.retain(|_, session| session.owner != owner);
+        }
+        if let Ok(mut prompts) = self.prompts.lock() {
+            prompts.retain(|_, prompt| prompt.owner != owner);
+        }
+        if let Ok(mut identities) = self.identities.lock() {
+            identities.remove(owner);
+        }
+    }
+
+    fn lock_objects(
+        &self,
+        owner: &str,
+        objects: &[Path<'static>],
+    ) -> Result<Vec<Path<'static>>, MethodErr> {
+        let subject = self.grant_subject(owner)?;
+        let mut grants = lock_method(&self.grants)?;
+        let mut locked = Vec::new();
+        for object in objects {
+            match parse_object_path(object)? {
+                PromptObjectRef::Collection => {
+                    grants.retain(|(grant_subject, _), _| grant_subject != &subject);
+                    locked.push(object.clone());
+                }
+                PromptObjectRef::Item(id) => {
+                    grants.remove(&(subject.clone(), id));
+                    locked.push(object.clone());
+                }
+            }
+        }
+        Ok(locked)
+    }
+
+    fn grant_subject(&self, owner: &str) -> Result<String, MethodErr> {
+        Ok(lock_method(&self.identities)?.get(owner).map_or_else(
+            || format!("bus:{owner}"),
+            |identity| identity.grant_subject.clone(),
+        ))
+    }
+
+    fn create_prompt(
+        &self,
+        owner: &str,
+        action: PromptAction,
+    ) -> Result<(u64, Path<'static>), MethodErr> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        lock_method(&self.prompts)?.insert(
+            id,
+            PendingPrompt {
+                owner: owner.to_owned(),
+                action,
+                started: false,
+            },
+        );
+        Ok((id, prompt_path(id)))
+    }
+
+    fn start_prompt(self: &Arc<Self>, id: u64, owner: &str) -> Result<(), MethodErr> {
+        {
+            let mut prompts = lock_method(&self.prompts)?;
+            let prompt = prompts
+                .get_mut(&id)
+                .ok_or_else(|| MethodErr::no_path(&prompt_path(id)))?;
+            ensure_owner(&prompt.owner, owner)?;
+            if prompt.started {
+                return Err(MethodErr::failed(&"prompt has already started"));
+            }
+            prompt.started = true;
+        }
+        let agent = Arc::clone(self);
+        thread::Builder::new()
+            .name(format!("factorseal-approval-{id}"))
+            .spawn(move || {
+                let approved = agent.ask_for_approval(id);
+                let _ = agent.approval_sender.send(ApprovalEvent {
+                    prompt_id: id,
+                    approved,
+                });
+            })
+            .map_err(|error| MethodErr::failed(&error))?;
+        Ok(())
+    }
+
+    fn dismiss_prompt(&self, id: u64, owner: &str) -> Result<(), MethodErr> {
+        let prompts = lock_method(&self.prompts)?;
+        let prompt = prompts
+            .get(&id)
+            .ok_or_else(|| MethodErr::no_path(&prompt_path(id)))?;
+        ensure_owner(&prompt.owner, owner)?;
+        self.approval_sender
+            .send(ApprovalEvent {
+                prompt_id: id,
+                approved: false,
+            })
+            .map_err(|error| MethodErr::failed(&error))
+    }
+
+    fn ask_for_approval(&self, id: u64) -> bool {
+        let Ok(_gate) = self.approval_gate.lock() else {
+            return false;
+        };
+        let Ok(prompts) = self.prompts.lock() else {
+            return false;
+        };
+        let Some(prompt) = prompts.get(&id) else {
+            return false;
+        };
+        let summary = self.action_summary(&prompt.action);
+        let mut identity = self
+            .identities
+            .lock()
+            .ok()
+            .and_then(|identities| identities.get(&prompt.owner).cloned())
+            .unwrap_or_else(|| CallerIdentity {
+                bus_name: prompt.owner.clone(),
+                process_id: None,
+                executable: None,
+                grant_subject: format!("bus:{}", prompt.owner),
+            });
+        drop(prompts);
+        if identity.process_id.is_none() {
+            identity = resolve_caller_identity(&identity.bus_name);
+            if let Ok(mut identities) = self.identities.lock() {
+                identities.insert(identity.bus_name.clone(), identity.clone());
+            }
+        }
+
+        let mut tty = match OpenOptions::new().read(true).write(true).open("/dev/tty") {
+            Ok(tty) => tty,
+            Err(error) => {
+                eprintln!("factorseal: cannot request approval without /dev/tty: {error}");
+                return false;
+            }
+        };
+        let process = identity.executable.as_ref().map_or_else(
+            || identity.bus_name.clone(),
+            |path| path.display().to_string(),
+        );
+        let pid = identity
+            .process_id
+            .map_or_else(String::new, |pid| format!(" (pid {pid})"));
+        let seconds = self.options.approval_ttl.as_secs();
+        if writeln!(
+            tty,
+            "\nFactorSeal request\n  application: {process}{pid}\n  action: {summary}\nAllow for {seconds} seconds? [y/N] "
+        )
+        .and_then(|()| tty.flush())
+        .is_err()
+        {
+            return false;
+        }
+        let mut answer = String::new();
+        BufReader::new(tty).read_line(&mut answer).is_ok()
+            && matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+    }
+
+    fn complete_prompt(
+        &self,
+        event: ApprovalEvent,
+    ) -> Result<Option<PromptCompletion>, SecretServiceError> {
+        let Some(prompt) = lock(&self.prompts)?.remove(&event.prompt_id) else {
+            return Ok(None);
+        };
+        if !event.approved {
+            return Ok(Some(PromptCompletion::dismissed(event.prompt_id)));
+        }
+
+        let mut created = None;
+        let mut deleted = None;
+        let result = match prompt.action {
+            PromptAction::Unlock { objects } => {
+                let mut paths = Vec::new();
+                for object in objects {
+                    match object {
+                        PromptObjectRef::Collection => {
+                            self.grant(&prompt.owner, COLLECTION_RESOURCE)
+                                .map_err(method_service)?;
+                            paths.push(collection_path());
+                        }
+                        PromptObjectRef::Item(id) => {
+                            self.grant(&prompt.owner, &id).map_err(method_service)?;
+                            paths.push(item_path(&id));
+                        }
+                    }
+                }
+                CompletionResult::Paths(paths)
+            }
+            PromptAction::Create { item, secret } => {
+                let previous = match self.vault.get(&item.service, &item.account) {
+                    Ok(secret) => Some(secret),
+                    Err(VaultError::NoEntry) => None,
+                    Err(error) => return Err(error.into()),
+                };
+                let mut index = lock(&self.index)?;
+                let mut updated = index.clone();
+                if let Some(existing) = updated.items.iter_mut().find(|value| value.id == item.id) {
+                    existing.clone_from(&item);
+                } else {
+                    updated.items.push((*item).clone());
+                }
+                let bytes = serde_json::to_vec(&updated)
+                    .map_err(|error| SecretServiceError::InvalidIndex(error.to_string()))?;
+
+                self.vault.set(&item.service, &item.account, &secret)?;
+                if let Err(error) = self.vault.write_secret_service_index(&bytes) {
+                    let rollback = restore_entry(
+                        &self.vault,
+                        &item.service,
+                        &item.account,
+                        previous.as_ref().map(|value| value.as_slice()),
+                    );
+                    return Err(service_transaction_error(&error, rollback.as_ref().err()));
+                }
+                *index = updated;
+                self.grant(&prompt.owner, &item.id)
+                    .map_err(method_service)?;
+                created = Some((*item).clone());
+                CompletionResult::Path(item_path(&item.id))
+            }
+            PromptAction::Delete { id } => {
+                let mut index = lock(&self.index)?;
+                let item = index
+                    .items
+                    .iter()
+                    .find(|item| item.id == id)
+                    .cloned()
+                    .ok_or_else(|| {
+                        SecretServiceError::InvalidIndex(format!("unknown item {id}"))
+                    })?;
+                let previous = self.vault.get(&item.service, &item.account)?;
+                let mut updated = index.clone();
+                updated.items.retain(|item| item.id != id);
+                let bytes = serde_json::to_vec(&updated)
+                    .map_err(|error| SecretServiceError::InvalidIndex(error.to_string()))?;
+
+                self.vault.delete(&item.service, &item.account)?;
+                if let Err(error) = self.vault.write_secret_service_index(&bytes) {
+                    let rollback = self.vault.set(&item.service, &item.account, &previous);
+                    return Err(service_transaction_error(&error, rollback.as_ref().err()));
+                }
+                *index = updated;
+                deleted = Some(id);
+                CompletionResult::Empty
+            }
+        };
+        Ok(Some(PromptCompletion {
+            prompt_id: event.prompt_id,
+            dismissed: false,
+            result,
+            created,
+            deleted,
+        }))
+    }
+
+    fn action_summary(&self, action: &PromptAction) -> String {
+        match action {
+            PromptAction::Unlock { objects } => {
+                if objects
+                    .iter()
+                    .any(|object| matches!(object, PromptObjectRef::Collection))
+                {
+                    return "access all secrets in the FactorSeal collection".to_owned();
+                }
+                let labels = self
+                    .index
+                    .lock()
+                    .ok()
+                    .map(|index| {
+                        objects
+                            .iter()
+                            .filter_map(|object| {
+                                let PromptObjectRef::Item(id) = object else {
+                                    return None;
+                                };
+                                index
+                                    .items
+                                    .iter()
+                                    .find(|item| item.id == *id)
+                                    .map(|item| {
+                                        format!(
+                                            "'{}' ({} / {})",
+                                            item.label, item.service, item.account
+                                        )
+                                    })
+                                    .or_else(|| Some(id.clone()))
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                format!(
+                    "read or update {} requested secret(s): {}",
+                    labels.len(),
+                    labels.join(", ")
+                )
+            }
+            PromptAction::Create { item, .. } => {
+                format!(
+                    "store secret '{}' for {} / {}",
+                    item.label, item.service, item.account
+                )
+            }
+            PromptAction::Delete { id } => self
+                .index
+                .lock()
+                .ok()
+                .and_then(|index| {
+                    index.items.iter().find(|item| item.id == *id).map(|item| {
+                        format!(
+                            "delete secret '{}' for {} / {}",
+                            item.label, item.service, item.account
+                        )
+                    })
+                })
+                .unwrap_or_else(|| format!("delete secret {id}")),
+        }
+    }
+}
+
+struct Interfaces {
+    service: IfaceToken<ServiceObject>,
+    collection: IfaceToken<CollectionObject>,
+    item: IfaceToken<ItemObject>,
+}
+
+#[allow(clippy::too_many_lines)]
+fn register_interfaces(crossroads: &mut Crossroads) -> Interfaces {
+    let session = crossroads.register("org.freedesktop.Secret.Session", |builder| {
+        builder.method(
+            "Close",
+            (),
+            (),
+            |context, object: &mut SessionObject, ()| {
+                let owner = sender(context)?;
+                ensure_owner(&object.owner, &owner)?;
+                object.agent.close_session(context.path(), &owner)?;
+                Ok(())
+            },
+        );
+    });
+
+    let prompt = crossroads.register("org.freedesktop.Secret.Prompt", |builder| {
+        builder.signal::<(bool, DynVariant), _>("Completed", ("dismissed", "result"));
+        builder.method(
+            "Prompt",
+            ("window_id",),
+            (),
+            |context, object: &mut PromptObject, (_window_id,): (String,)| {
+                let owner = sender(context)?;
+                ensure_owner(&object.owner, &owner)?;
+                object.agent.start_prompt(object.id, &owner)?;
+                Ok(())
+            },
+        );
+        builder.method(
+            "Dismiss",
+            (),
+            (),
+            |context, object: &mut PromptObject, ()| {
+                let owner = sender(context)?;
+                ensure_owner(&object.owner, &owner)?;
+                object.agent.dismiss_prompt(object.id, &owner)?;
+                Ok(())
+            },
+        );
+    });
+
+    let prompt_for_item = prompt;
+    let item = crossroads.register("org.freedesktop.Secret.Item", move |builder| {
+        builder.method_with_cr("Delete", (), ("prompt",), move |context, crossroads, ()| {
+            let owner = sender(context)?;
+            let object = crossroads
+                .data_mut::<ItemObject>(context.path())
+                .ok_or_else(|| MethodErr::no_path(context.path()))?;
+            let agent = Arc::clone(&object.agent);
+            let id = object.id.clone();
+            let (prompt_id, path) = agent.create_prompt(&owner, PromptAction::Delete { id })?;
+            crossroads.insert(
+                path.clone(),
+                &[prompt_for_item],
+                PromptObject {
+                    agent,
+                    id: prompt_id,
+                    owner,
+                },
+            );
+            Ok((path,))
+        });
+        builder.method(
+            "GetSecret",
+            ("session",),
+            ("secret",),
+            |context, object: &mut ItemObject, (session,): (Path<'static>,)| {
+                let owner = sender(context)?;
+                if !object.agent.has_grant(&owner, &object.id)? {
+                    return Err(is_locked());
+                }
+                let item = object.agent.item(&object.id)?;
+                let secret = object
+                    .agent
+                    .vault
+                    .get(&item.service, &item.account)
+                    .map_err(vault_method)?;
+                Ok((object
+                    .agent
+                    .encrypt_secret(&session, &owner, &secret, item.content_type)?,))
+            },
+        );
+        builder.method(
+            "SetSecret",
+            ("secret",),
+            (),
+            |context, object: &mut ItemObject, (secret,): (Secret,)| {
+                let owner = sender(context)?;
+                if !object.agent.has_grant(&owner, &object.id)? {
+                    return Err(is_locked());
+                }
+                let plaintext = object.agent.decrypt_secret(&secret, &owner)?;
+                object
+                    .agent
+                    .set_item_secret(&object.id, &plaintext, secret.3)
+            },
+        );
+        builder
+            .property::<bool, _>("Locked")
+            .get(|context, object| {
+                let owner = property_sender(context)?;
+                Ok(!object.agent.has_grant(&owner, &object.id)?)
+            });
+        builder
+            .property::<HashMap<String, String>, _>("Attributes")
+            .get(|_, object| Ok(object.agent.item(&object.id)?.attributes))
+            .set(|context, object, attributes| {
+                let owner = property_sender(context)?;
+                if !object.agent.has_grant(&owner, &object.id)? {
+                    return Err(is_locked());
+                }
+                let mut index = lock_method(&object.agent.index)?;
+                let item = index
+                    .items
+                    .iter_mut()
+                    .find(|item| item.id == object.id)
+                    .ok_or_else(|| no_item(&object.id))?;
+                let (service, account) = storage_names(&attributes, &item.id)?;
+                if service != item.service || account != item.account {
+                    return Err(MethodErr::failed(
+                        &"changing service or username is not supported",
+                    ));
+                }
+                item.attributes.clone_from(&attributes);
+                item.modified = unix_time();
+                object.agent.save_index(&index)?;
+                Ok(Some(attributes))
+            });
+        builder
+            .property::<String, _>("Label")
+            .get(|_, object| Ok(object.agent.item(&object.id)?.label))
+            .set(|context, object, label| {
+                let owner = property_sender(context)?;
+                if !object.agent.has_grant(&owner, &object.id)? {
+                    return Err(is_locked());
+                }
+                let mut index = lock_method(&object.agent.index)?;
+                let item = index
+                    .items
+                    .iter_mut()
+                    .find(|item| item.id == object.id)
+                    .ok_or_else(|| no_item(&object.id))?;
+                item.label.clone_from(&label);
+                item.modified = unix_time();
+                object.agent.save_index(&index)?;
+                Ok(Some(label))
+            });
+        builder
+            .property::<String, _>("Type")
+            .get(|_, object| Ok(object.agent.item(&object.id)?.item_type))
+            .set(|context, object, item_type| {
+                let owner = property_sender(context)?;
+                if !object.agent.has_grant(&owner, &object.id)? {
+                    return Err(is_locked());
+                }
+                let mut index = lock_method(&object.agent.index)?;
+                let item = index
+                    .items
+                    .iter_mut()
+                    .find(|item| item.id == object.id)
+                    .ok_or_else(|| no_item(&object.id))?;
+                item.item_type.clone_from(&item_type);
+                item.modified = unix_time();
+                object.agent.save_index(&index)?;
+                Ok(Some(item_type))
+            });
+        builder
+            .property::<u64, _>("Created")
+            .get(|_, object| Ok(object.agent.item(&object.id)?.created));
+        builder
+            .property::<u64, _>("Modified")
+            .get(|_, object| Ok(object.agent.item(&object.id)?.modified));
+    });
+
+    let prompt_for_collection = prompt;
+    let collection = crossroads.register("org.freedesktop.Secret.Collection", move |builder| {
+        builder.signal::<(Path<'static>,), _>("ItemCreated", ("item",));
+        builder.signal::<(Path<'static>,), _>("ItemDeleted", ("item",));
+        builder.signal::<(Path<'static>,), _>("ItemChanged", ("item",));
+        builder.method(
+            "Delete",
+            (),
+            ("prompt",),
+            |_, _: &mut CollectionObject, ()| -> Result<(Path<'static>,), MethodErr> {
+                Err(MethodErr::failed(
+                    &"the FactorSeal collection cannot be deleted",
+                ))
+            },
+        );
+        builder.method(
+            "SearchItems",
+            ("attributes",),
+            ("results",),
+            |_, object: &mut CollectionObject, (attributes,): (HashMap<String, String>,)| {
+                let paths: Vec<Path<'static>> = object
+                    .0
+                    .search(&attributes)?
+                    .iter()
+                    .map(|item| item_path(&item.id))
+                    .collect();
+                Ok((paths,))
+            },
+        );
+        builder.method_with_cr(
+            "CreateItem",
+            ("properties", "secret", "replace"),
+            ("item", "prompt"),
+            move |context, crossroads, (properties, secret, replace): (PropMap, Secret, bool)| {
+                let owner = sender(context)?;
+                let object = crossroads
+                    .data_mut::<CollectionObject>(context.path())
+                    .ok_or_else(|| MethodErr::no_path(context.path()))?;
+                let agent = Arc::clone(&object.0);
+                let plaintext = agent.decrypt_secret(&secret, &owner)?;
+                let label = prop_cast::<String>(&properties, ITEM_LABEL)
+                    .cloned()
+                    .ok_or_else(|| MethodErr::invalid_arg(&ITEM_LABEL))?;
+                let attributes = property_string_map(&properties, ITEM_ATTRIBUTES)?;
+                let existing = if replace {
+                    agent.search(&attributes)?.into_iter().next()
+                } else {
+                    None
+                };
+                let id = existing
+                    .as_ref()
+                    .map_or_else(random_id, |item| Ok(item.id.clone()))
+                    .map_err(vault_method)?;
+                let (service, account) = storage_names(&attributes, &id)?;
+                if let Some(same_entry) = agent
+                    .all_items()?
+                    .into_iter()
+                    .find(|item| item.service == service && item.account == account)
+                {
+                    if replace {
+                        if existing
+                            .as_ref()
+                            .is_none_or(|item| item.id != same_entry.id)
+                        {
+                            return Err(MethodErr::failed(
+                                &"replace attributes resolve to a different existing item",
+                            ));
+                        }
+                    } else {
+                        return Err(MethodErr::failed(
+                            &"FactorSeal already contains this service and account",
+                        ));
+                    }
+                } else if !replace
+                    && agent
+                        .vault
+                        .contains(&service, &account)
+                        .map_err(vault_method)?
+                {
+                    return Err(MethodErr::failed(
+                        &"FactorSeal already contains this service and account",
+                    ));
+                }
+                let now = unix_time();
+                let item = IndexItem {
+                    id,
+                    service,
+                    account,
+                    label,
+                    attributes,
+                    content_type: secret.3,
+                    item_type: existing.as_ref().map_or_else(
+                        || "org.freedesktop.Secret.Generic".to_owned(),
+                        |item| item.item_type.clone(),
+                    ),
+                    created: existing.as_ref().map_or(now, |item| item.created),
+                    modified: now,
+                };
+                let (prompt_id, path) = agent.create_prompt(
+                    &owner,
+                    PromptAction::Create {
+                        item: Box::new(item),
+                        secret: plaintext,
+                    },
+                )?;
+                crossroads.insert(
+                    path.clone(),
+                    &[prompt_for_collection],
+                    PromptObject {
+                        agent,
+                        id: prompt_id,
+                        owner,
+                    },
+                );
+                Ok((root_path(), path))
+            },
+        );
+        builder
+            .property::<Vec<Path<'static>>, _>("Items")
+            .get(|_, object| {
+                Ok(object
+                    .0
+                    .all_items()?
+                    .iter()
+                    .map(|item| item_path(&item.id))
+                    .collect())
+            });
+        builder
+            .property::<String, _>("Label")
+            .get(|_, _| Ok("FactorSeal".to_owned()))
+            .set(|_, _, _| Err(MethodErr::ro_property(&"Label")));
+        builder
+            .property::<bool, _>("Locked")
+            .get(|context, object| {
+                let owner = property_sender(context)?;
+                Ok(!object.0.has_grant(&owner, COLLECTION_RESOURCE)?)
+            });
+        builder.property::<u64, _>("Created").get(|_, _| Ok(0));
+        builder.property::<u64, _>("Modified").get(|_, _| Ok(0));
+    });
+
+    let session_for_service = session;
+    let prompt_for_service = prompt;
+    let service = crossroads.register("org.freedesktop.Secret.Service", move |builder| {
+        builder.signal::<(Path<'static>,), _>("CollectionCreated", ("collection",));
+        builder.signal::<(Path<'static>,), _>("CollectionDeleted", ("collection",));
+        builder.signal::<(Path<'static>,), _>("CollectionChanged", ("collection",));
+        builder.method_with_cr(
+            "OpenSession",
+            ("algorithm", "input"),
+            ("output", "result"),
+            move |context, crossroads, (algorithm, input): (String, DynVariant)| {
+                let (output, cipher) = negotiate_session(&algorithm, &input)?;
+                let owner = sender(context)?;
+                let object = crossroads
+                    .data_mut::<ServiceObject>(context.path())
+                    .ok_or_else(|| MethodErr::no_path(context.path()))?;
+                let agent = Arc::clone(&object.0);
+                let path = agent.open_session(&owner, cipher)?;
+                crossroads.insert(
+                    path.clone(),
+                    &[session_for_service],
+                    SessionObject { agent, owner },
+                );
+                Ok((output, path))
+            },
+        );
+        builder.method(
+            "CreateCollection",
+            ("properties", "alias"),
+            ("collection", "prompt"),
+            |_, _: &mut ServiceObject, (properties, _alias): (PropMap, String)| {
+                let _ = prop_cast::<String>(&properties, COLLECTION_LABEL);
+                Ok((collection_path(), root_path()))
+            },
+        );
+        builder.method(
+            "SearchItems",
+            ("attributes",),
+            ("unlocked", "locked"),
+            |context, object: &mut ServiceObject, (attributes,): (HashMap<String, String>,)| {
+                let owner = sender(context)?;
+                let mut unlocked = Vec::new();
+                let mut locked_items = Vec::new();
+                for item in object.0.search(&attributes)? {
+                    if object.0.has_grant(&owner, &item.id)? {
+                        unlocked.push(item_path(&item.id));
+                    } else {
+                        locked_items.push(item_path(&item.id));
+                    }
+                }
+                Ok((unlocked, locked_items))
+            },
+        );
+        builder.method_with_cr(
+            "Unlock",
+            ("objects",),
+            ("unlocked", "prompt"),
+            move |context, crossroads, (paths,): (Vec<Path<'static>>,)| {
+                let owner = sender(context)?;
+                let object = crossroads
+                    .data_mut::<ServiceObject>(context.path())
+                    .ok_or_else(|| MethodErr::no_path(context.path()))?;
+                let agent = Arc::clone(&object.0);
+                let mut immediate = Vec::new();
+                let mut pending = Vec::new();
+                for path in paths {
+                    let object = parse_object_path(&path)?;
+                    let resource = match &object {
+                        PromptObjectRef::Collection => COLLECTION_RESOURCE,
+                        PromptObjectRef::Item(id) => id,
+                    };
+                    if agent.has_grant(&owner, resource)? {
+                        immediate.push(path);
+                    } else {
+                        pending.push(object);
+                    }
+                }
+                if pending.is_empty() {
+                    return Ok((immediate, root_path()));
+                }
+                let (prompt_id, path) =
+                    agent.create_prompt(&owner, PromptAction::Unlock { objects: pending })?;
+                crossroads.insert(
+                    path.clone(),
+                    &[prompt_for_service],
+                    PromptObject {
+                        agent,
+                        id: prompt_id,
+                        owner,
+                    },
+                );
+                Ok((immediate, path))
+            },
+        );
+        builder.method(
+            "Lock",
+            ("objects",),
+            ("locked", "prompt"),
+            |context, object: &mut ServiceObject, (paths,): (Vec<Path<'static>>,)| {
+                let owner = sender(context)?;
+                let locked = object.0.lock_objects(&owner, &paths)?;
+                Ok((locked, root_path()))
+            },
+        );
+        builder.method(
+            "GetSecrets",
+            ("items", "session"),
+            ("secrets",),
+            |context,
+             object: &mut ServiceObject,
+             (paths, session): (Vec<Path<'static>>, Path<'static>)| {
+                let owner = sender(context)?;
+                let mut secrets = HashMap::new();
+                for path in paths {
+                    let PromptObjectRef::Item(id) = parse_object_path(&path)? else {
+                        return Err(MethodErr::invalid_arg(&path));
+                    };
+                    if !object.0.has_grant(&owner, &id)? {
+                        continue;
+                    }
+                    let item = object.0.item(&id)?;
+                    let secret = object
+                        .0
+                        .vault
+                        .get(&item.service, &item.account)
+                        .map_err(vault_method)?;
+                    secrets.insert(
+                        path,
+                        object
+                            .0
+                            .encrypt_secret(&session, &owner, &secret, item.content_type)?,
+                    );
+                }
+                Ok((secrets,))
+            },
+        );
+        builder.method(
+            "ReadAlias",
+            ("name",),
+            ("collection",),
+            |_, _: &mut ServiceObject, (name,): (String,)| {
+                if name.is_empty() {
+                    Ok((root_path(),))
+                } else if name == "default" {
+                    Ok((default_alias_path(),))
+                } else {
+                    Ok((collection_path(),))
+                }
+            },
+        );
+        builder.method(
+            "SetAlias",
+            ("name", "collection"),
+            (),
+            |_, _: &mut ServiceObject, (_name, collection): (String, Path<'static>)| {
+                if collection != collection_path() && collection != default_alias_path() {
+                    return Err(MethodErr::invalid_arg(&collection));
+                }
+                Ok(())
+            },
+        );
+        builder
+            .property::<Vec<Path<'static>>, _>("Collections")
+            .get(|_, _| Ok(vec![collection_path()]));
+    });
+
+    Interfaces {
+        service,
+        collection,
+        item,
+    }
+}
+
+fn sender(context: &Context) -> Result<String, MethodErr> {
+    context
+        .message()
+        .sender()
+        .map(|sender| sender.to_string())
+        .ok_or_else(|| MethodErr::failed(&"D-Bus caller has no unique name"))
+}
+
+fn property_sender(context: &PropContext) -> Result<String, MethodErr> {
+    context
+        .message()
+        .and_then(Message::sender)
+        .map(|sender| sender.to_string())
+        .ok_or_else(|| MethodErr::failed(&"D-Bus caller has no unique name"))
+}
+
+fn ensure_owner(expected: &str, actual: &str) -> Result<(), MethodErr> {
+    if expected == actual {
+        Ok(())
+    } else {
+        Err(MethodErr::failed(
+            &"Secret Service object belongs to another D-Bus caller",
+        ))
+    }
+}
+
+fn attributes_match(item: &HashMap<String, String>, query: &HashMap<String, String>) -> bool {
+    query
+        .iter()
+        .all(|(key, value)| item.get(key) == Some(value))
+}
+
+fn storage_names(
+    attributes: &HashMap<String, String>,
+    id: &str,
+) -> Result<(String, String), MethodErr> {
+    let service = attributes
+        .get("service")
+        .cloned()
+        .unwrap_or_else(|| "secret-service".to_owned());
+    let account = attributes
+        .get("username")
+        .or_else(|| attributes.get("account"))
+        .cloned()
+        .unwrap_or_else(|| id.to_owned());
+    if service.is_empty() || account.is_empty() {
+        return Err(MethodErr::invalid_arg(&"empty service or account"));
+    }
+    Ok((service, account))
+}
+
+fn property_string_map(
+    properties: &PropMap,
+    name: &str,
+) -> Result<HashMap<String, String>, MethodErr> {
+    if let Some(map) = prop_cast::<HashMap<String, String>>(properties, name) {
+        return Ok(map.clone());
+    }
+    let value = properties
+        .get(name)
+        .ok_or_else(|| MethodErr::invalid_arg(&name))?;
+    let mut values = value
+        .0
+        .as_iter()
+        .ok_or_else(|| MethodErr::invalid_arg(&name))?;
+    let mut result = HashMap::new();
+    while let Some(key) = values.next() {
+        let value = values.next().ok_or_else(|| MethodErr::invalid_arg(&name))?;
+        let key = key.as_str().ok_or_else(|| MethodErr::invalid_arg(&name))?;
+        let value = value
+            .as_str()
+            .ok_or_else(|| MethodErr::invalid_arg(&name))?;
+        result.insert(key.to_owned(), value.to_owned());
+    }
+    Ok(result)
+}
+
+fn parse_object_path(path: &Path<'_>) -> Result<PromptObjectRef, MethodErr> {
+    let value: &str = path.as_ref();
+    if matches!(value, COLLECTION_PATH | DEFAULT_ALIAS_PATH) {
+        return Ok(PromptObjectRef::Collection);
+    }
+    if let Some(id) = value.strip_prefix(ITEM_PREFIX) {
+        if !id.is_empty() {
+            return Ok(PromptObjectRef::Item(id.to_owned()));
+        }
+    }
+    Err(MethodErr::no_path(path))
+}
+
+fn dbus_process_id(owner: &str) -> Option<u32> {
+    let connection = dbus::blocking::Connection::new_session().ok()?;
+    let proxy = connection.with_proxy(
+        "org.freedesktop.DBus",
+        "/org/freedesktop/DBus",
+        Duration::from_secs(2),
+    );
+    let result: Result<(u32,), _> = proxy.method_call(
+        "org.freedesktop.DBus",
+        "GetConnectionUnixProcessID",
+        (owner,),
+    );
+    result.ok().map(|value| value.0)
+}
+
+fn resolve_caller_identity(owner: &str) -> CallerIdentity {
+    let process_id = dbus_process_id(owner);
+    let process_start_time = process_id.and_then(proc_start_time);
+    let executable = process_id.and_then(|id| std::fs::read_link(format!("/proc/{id}/exe")).ok());
+    let grant_subject = match (process_id, process_start_time) {
+        (Some(process_id), Some(start_time)) => {
+            format!("process:{process_id}:start:{start_time}")
+        }
+        _ => format!("bus:{owner}"),
+    };
+    CallerIdentity {
+        bus_name: owner.to_owned(),
+        process_id,
+        executable,
+        grant_subject,
+    }
+}
+
+fn proc_start_time(process_id: u32) -> Option<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/{process_id}/stat")).ok()?;
+    let (_, fields) = stat.rsplit_once(')')?;
+    fields.split_whitespace().nth(19)?.parse().ok()
+}
+
+fn negotiate_session(
+    algorithm: &str,
+    input: &DynVariant,
+) -> Result<(DynVariant, SessionCipher), MethodErr> {
+    match algorithm {
+        ALGORITHM_PLAIN => Ok((
+            Variant(Box::new(String::new()) as Box<dyn RefArg>),
+            SessionCipher::Plain,
+        )),
+        ALGORITHM_DH => {
+            let client_bytes = dbus::arg::cast::<Vec<u8>>(&input.0)
+                .ok_or_else(|| MethodErr::invalid_arg(&"DH public key"))?;
+            let prime = BigUint::from_bytes_be(&DH_PRIME_BYTES);
+            let client_public = BigUint::from_bytes_be(client_bytes);
+            let two = BigUint::from(2_u8);
+            if client_public < two || client_public > &prime - &two {
+                return Err(MethodErr::invalid_arg(&"DH public key range"));
+            }
+
+            let mut private_bytes = Zeroizing::new([0_u8; DH_BYTES]);
+            getrandom::fill(&mut *private_bytes).map_err(|error| MethodErr::failed(&error))?;
+            let private = BigUint::from_bytes_be(&*private_bytes);
+            let server_public = two.modpow(&private, &prime);
+            let shared = client_public.modpow(&private, &prime);
+            let shared = pad_dh_value(&shared)?;
+            let mut key = Zeroizing::new([0_u8; AES_KEY_BYTES]);
+            Hkdf::<Sha256>::new(None, &shared)
+                .expand(&[], &mut *key)
+                .map_err(|_| MethodErr::failed(&"could not derive Secret Service session key"))?;
+            let output = pad_dh_value(&server_public)?;
+            Ok((
+                Variant(Box::new(output) as Box<dyn RefArg>),
+                SessionCipher::Dh(key),
+            ))
+        }
+        _ => Err(MethodErr::failed(&format!(
+            "unsupported Secret Service session algorithm `{algorithm}`"
+        ))),
+    }
+}
+
+fn pad_dh_value(value: &BigUint) -> Result<Vec<u8>, MethodErr> {
+    let bytes = value.to_bytes_be();
+    if bytes.len() > DH_BYTES {
+        return Err(MethodErr::invalid_arg(&"oversized DH value"));
+    }
+    let mut padded = vec![0_u8; DH_BYTES - bytes.len()];
+    padded.extend_from_slice(&bytes);
+    Ok(padded)
+}
+
+fn random_id() -> Result<String, VaultError> {
+    let mut bytes = [0_u8; 16];
+    getrandom::fill(&mut bytes)?;
+    Ok(hex::encode(bytes))
+}
+
+fn unix_time() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn item_path(id: &str) -> Path<'static> {
+    Path::new(format!("{ITEM_PREFIX}{id}")).expect("hex item id is a valid D-Bus path")
+}
+
+fn collection_signal(member: &str, item: Path<'static>) -> Message {
+    let path = collection_path();
+    let interface =
+        Interface::new("org.freedesktop.Secret.Collection").expect("valid collection interface");
+    let member = Member::new(member.to_owned()).expect("valid collection signal");
+    Message::signal(&path, &interface, &member).append1(item)
+}
+
+fn prompt_path(id: u64) -> Path<'static> {
+    Path::new(format!("{PROMPT_PREFIX}{id}")).expect("numeric prompt id is a valid D-Bus path")
+}
+
+fn collection_path() -> Path<'static> {
+    Path::new(COLLECTION_PATH).expect("valid collection path")
+}
+
+fn default_alias_path() -> Path<'static> {
+    Path::new(DEFAULT_ALIAS_PATH).expect("valid alias path")
+}
+
+fn root_path() -> Path<'static> {
+    Path::new(ROOT_PATH).expect("valid root path")
+}
+
+fn dbus_path(value: &str) -> Result<Path<'static>, MethodErr> {
+    Path::new(value.to_owned()).map_err(|error| MethodErr::invalid_arg(&error))
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn vault_method(error: VaultError) -> MethodErr {
+    MethodErr::failed(&error)
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn method_service(error: MethodErr) -> SecretServiceError {
+    SecretServiceError::InvalidIndex(error.to_string())
+}
+
+fn restore_entry(
+    vault: &UnlockedVault,
+    service: &str,
+    account: &str,
+    previous: Option<&[u8]>,
+) -> Result<(), VaultError> {
+    if let Some(previous) = previous {
+        vault.set(service, account, previous)
+    } else {
+        match vault.delete(service, account) {
+            Ok(()) | Err(VaultError::NoEntry) => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+}
+
+fn transaction_error(error: &VaultError, rollback: Option<&VaultError>) -> MethodErr {
+    MethodErr::failed(&transaction_message(error, rollback))
+}
+
+fn service_transaction_error(
+    error: &VaultError,
+    rollback: Option<&VaultError>,
+) -> SecretServiceError {
+    SecretServiceError::InvalidIndex(transaction_message(error, rollback))
+}
+
+fn transaction_message(error: &VaultError, rollback: Option<&VaultError>) -> String {
+    rollback.map_or_else(
+        || format!("could not commit Secret Service metadata: {error}"),
+        |rollback| {
+            format!(
+                "could not commit Secret Service metadata: {error}; entry rollback also failed: {rollback}"
+            )
+        },
+    )
+}
+
+fn no_item(id: &str) -> MethodErr {
+    (
+        "org.freedesktop.Secret.Error.NoSuchObject",
+        format!("no Secret Service item {id}"),
+    )
+        .into()
+}
+
+fn no_session(path: &Path<'_>) -> MethodErr {
+    (
+        "org.freedesktop.Secret.Error.NoSuchObject",
+        format!("no Secret Service session {path}"),
+    )
+        .into()
+}
+
+fn is_locked() -> MethodErr {
+    (
+        "org.freedesktop.Secret.Error.IsLocked",
+        "the application has no active FactorSeal grant",
+    )
+        .into()
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> Result<MutexGuard<'_, T>, SecretServiceError> {
+    mutex.lock().map_err(|_| SecretServiceError::Poisoned)
+}
+
+fn lock_method<T>(mutex: &Mutex<T>) -> Result<MutexGuard<'_, T>, MethodErr> {
+    mutex
+        .lock()
+        .map_err(|_| MethodErr::failed(&"Secret Service state lock was poisoned"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Vault;
+
+    fn agent() -> (tempfile::TempDir, Arc<Agent>) {
+        let directory = tempfile::tempdir().unwrap();
+        let vault = Vault::create_for_test(directory.path().join("vault")).unwrap();
+        let (sender, _receiver) = mpsc::channel();
+        let agent = Agent::new(vault, SecretServiceOptions::default(), sender).unwrap();
+        (directory, Arc::new(agent))
+    }
+
+    #[test]
+    fn subset_attribute_matching() {
+        let attributes = HashMap::from([
+            ("service".to_owned(), "example".to_owned()),
+            ("username".to_owned(), "alice".to_owned()),
+            ("extra".to_owned(), "value".to_owned()),
+        ]);
+        assert!(attributes_match(
+            &attributes,
+            &HashMap::from([("service".to_owned(), "example".to_owned())])
+        ));
+        assert!(!attributes_match(
+            &attributes,
+            &HashMap::from([("service".to_owned(), "other".to_owned())])
+        ));
+    }
+
+    #[test]
+    fn generic_items_get_stable_internal_names() {
+        let (service, account) = storage_names(&HashMap::new(), "abc").unwrap();
+        assert_eq!(service, "secret-service");
+        assert_eq!(account, "abc");
+    }
+
+    #[test]
+    fn grants_are_bound_to_the_callers_bus_connection() {
+        let (_directory, agent) = agent();
+        agent.grant(":1.10", "item").unwrap();
+
+        assert!(agent.has_grant(":1.10", "item").unwrap());
+        assert!(!agent.has_grant(":1.11", "item").unwrap());
+        assert!(!agent.has_grant(":1.10", "other").unwrap());
+    }
+
+    #[test]
+    fn reconnects_from_the_same_process_reuse_the_grant() {
+        let (_directory, agent) = agent();
+        let subject = "process:42:start:100".to_owned();
+        let mut identities = agent.identities.lock().unwrap();
+        for owner in [":1.10", ":1.11"] {
+            identities.insert(
+                owner.to_owned(),
+                CallerIdentity {
+                    bus_name: owner.to_owned(),
+                    process_id: Some(42),
+                    executable: Some(PathBuf::from("/example")),
+                    grant_subject: subject.clone(),
+                },
+            );
+        }
+        drop(identities);
+
+        agent.grant(":1.10", "item").unwrap();
+        assert!(agent.has_grant(":1.11", "item").unwrap());
+    }
+
+    #[test]
+    fn exact_search_imports_an_existing_cli_entry() {
+        let (_directory, agent) = agent();
+        agent.vault.set("example", "alice", b"secret").unwrap();
+        let attributes = HashMap::from([
+            ("target".to_owned(), "default".to_owned()),
+            ("service".to_owned(), "example".to_owned()),
+            ("username".to_owned(), "alice".to_owned()),
+        ]);
+
+        let found = agent.search(&attributes).unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].service, "example");
+        assert_eq!(found[0].account, "alice");
+        assert!(agent.vault.read_secret_service_index().unwrap().is_some());
+    }
+
+    #[test]
+    fn encrypted_session_derives_the_same_key_as_the_client() {
+        let prime = BigUint::from_bytes_be(&DH_PRIME_BYTES);
+        let generator = BigUint::from(2_u8);
+        let client_private = BigUint::from(42_u8);
+        let client_public = generator.modpow(&client_private, &prime);
+        let input = Variant(Box::new(pad_dh_value(&client_public).unwrap()) as Box<dyn RefArg>);
+
+        let (output, cipher) = negotiate_session(ALGORITHM_DH, &input).unwrap();
+        let server_public = dbus::arg::cast::<Vec<u8>>(&output.0).unwrap();
+        let shared = BigUint::from_bytes_be(server_public).modpow(&client_private, &prime);
+        let shared = pad_dh_value(&shared).unwrap();
+        let mut expected = [0_u8; AES_KEY_BYTES];
+        Hkdf::<Sha256>::new(None, &shared)
+            .expand(&[], &mut expected)
+            .unwrap();
+
+        let SessionCipher::Dh(actual) = cipher else {
+            panic!("expected encrypted session");
+        };
+        assert_eq!(*actual, expected);
+    }
+}

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -21,11 +21,17 @@ use crate::{Error, Result};
 
 const CONFIG_FILE: &str = "vault.json";
 const ENTRIES_DIRECTORY: &str = "entries";
+#[cfg(all(target_os = "linux", feature = "secret-service"))]
+const SECRET_SERVICE_INDEX_FILE: &str = "secret-service-index.fseal";
 const VAULT_FORMAT: &str = "factorseal-vault";
 const ENTRY_FORMAT: &str = "factorseal-entry";
+#[cfg(all(target_os = "linux", feature = "secret-service"))]
+const SECRET_SERVICE_INDEX_FORMAT: &str = "factorseal-secret-service-index";
 const CURRENT_VAULT_VERSION: u32 = 2;
 const PASSWORD_VAULT_VERSION: u32 = 1;
 const ENTRY_VERSION: u32 = 1;
+#[cfg(all(target_os = "linux", feature = "secret-service"))]
+const SECRET_SERVICE_INDEX_VERSION: u32 = 1;
 const KEY_BYTES: usize = 32;
 const NONCE_BYTES: usize = 24;
 #[cfg(feature = "password")]
@@ -34,6 +40,8 @@ const VAULT_ID_BYTES: usize = 16;
 const MAX_NAME_BYTES: usize = 1024;
 const MAX_CONFIG_BYTES: u64 = 1024 * 1024;
 const MAX_ENTRY_BYTES: u64 = 64 * 1024 * 1024;
+#[cfg(all(target_os = "linux", feature = "secret-service"))]
+const MAX_SECRET_SERVICE_INDEX_BYTES: u64 = 16 * 1024 * 1024;
 #[cfg(feature = "password")]
 const ARGON2_MEMORY_KIB: u32 = 64 * 1024;
 #[cfg(feature = "password")]
@@ -119,6 +127,15 @@ struct Argon2Config {
 
 #[derive(Debug, Serialize, Deserialize)]
 struct EntryFile {
+    format: String,
+    version: u32,
+    nonce: String,
+    ciphertext: String,
+}
+
+#[cfg(all(target_os = "linux", feature = "secret-service"))]
+#[derive(Debug, Serialize, Deserialize)]
+struct SecretServiceIndexFile {
     format: String,
     version: u32,
     nonce: String,
@@ -454,6 +471,64 @@ impl UnlockedVault {
     #[must_use]
     pub fn vault_id(&self) -> String {
         encode(&self.vault_id)
+    }
+
+    #[cfg(all(target_os = "linux", feature = "secret-service"))]
+    pub(crate) fn read_secret_service_index(&self) -> Result<Option<Zeroizing<Vec<u8>>>> {
+        let path = self.root.join(SECRET_SERVICE_INDEX_FILE);
+        let encoded = match read_limited(&path, MAX_SECRET_SERVICE_INDEX_BYTES) {
+            Ok(value) => value,
+            Err(Error::Io { source, .. }) if source.kind() == io::ErrorKind::NotFound => {
+                return Ok(None);
+            }
+            Err(error) => return Err(error),
+        };
+        let index: SecretServiceIndexFile =
+            deserialize(&encoded, &path).map_err(|_| Error::InvalidEntry)?;
+        if index.format != SECRET_SERVICE_INDEX_FORMAT
+            || index.version != SECRET_SERVICE_INDEX_VERSION
+        {
+            return Err(Error::InvalidEntry);
+        }
+        let nonce =
+            decode_array::<NONCE_BYTES>(&index.nonce, "nonce").map_err(|_| Error::InvalidEntry)?;
+        let ciphertext =
+            decode(&index.ciphertext, "ciphertext").map_err(|_| Error::InvalidEntry)?;
+        let cipher = XChaCha20Poly1305::new((&*self.key).into());
+        let plaintext = cipher
+            .decrypt(
+                XNonce::from_slice(&nonce),
+                Payload {
+                    msg: &ciphertext,
+                    aad: &secret_service_index_aad(&self.vault_id),
+                },
+            )
+            .map_err(|_| Error::Authentication)?;
+        Ok(Some(Zeroizing::new(plaintext)))
+    }
+
+    #[cfg(all(target_os = "linux", feature = "secret-service"))]
+    pub(crate) fn write_secret_service_index(&self, plaintext: &[u8]) -> Result<()> {
+        let mut nonce = [0_u8; NONCE_BYTES];
+        getrandom::fill(&mut nonce)?;
+        let cipher = XChaCha20Poly1305::new((&*self.key).into());
+        let ciphertext = cipher
+            .encrypt(
+                XNonce::from_slice(&nonce),
+                Payload {
+                    msg: plaintext,
+                    aad: &secret_service_index_aad(&self.vault_id),
+                },
+            )
+            .map_err(|_| Error::Authentication)?;
+        let index = SecretServiceIndexFile {
+            format: SECRET_SERVICE_INDEX_FORMAT.to_owned(),
+            version: SECRET_SERVICE_INDEX_VERSION,
+            nonce: encode(&nonce),
+            ciphertext: encode(&ciphertext),
+        };
+        let path = self.root.join(SECRET_SERVICE_INDEX_FILE);
+        atomic_write(&path, &serialize(&index, &path)?)
     }
 
     fn entry_path(&self, service: &str, account: &str) -> PathBuf {
@@ -949,6 +1024,13 @@ fn entry_aad(vault_id: &[u8; VAULT_ID_BYTES], service: &str, account: &str) -> V
     aad
 }
 
+#[cfg(all(target_os = "linux", feature = "secret-service"))]
+fn secret_service_index_aad(vault_id: &[u8; VAULT_ID_BYTES]) -> Vec<u8> {
+    let mut aad = b"factorseal/secret-service-index/v1\0".to_vec();
+    aad.extend_from_slice(vault_id);
+    aad
+}
+
 #[cfg(feature = "password")]
 fn vault_key_aad(vault_id: &[u8; VAULT_ID_BYTES]) -> Vec<u8> {
     let mut aad = b"factorseal/vault-key/v1\0".to_vec();
@@ -1197,6 +1279,29 @@ mod tests {
             vault.get("service", "second"),
             Err(Error::Authentication)
         ));
+    }
+
+    #[cfg(all(target_os = "linux", feature = "secret-service"))]
+    #[test]
+    fn secret_service_index_is_encrypted() {
+        let (_directory, _path, vault) = vault();
+        let metadata = b"metadata marker that must not appear on disk";
+        vault.write_secret_service_index(metadata).unwrap();
+
+        let stored = fs::read(vault.path().join(SECRET_SERVICE_INDEX_FILE)).unwrap();
+        assert!(
+            !stored
+                .windows(metadata.len())
+                .any(|window| window == metadata)
+        );
+        assert_eq!(
+            vault
+                .read_secret_service_index()
+                .unwrap()
+                .unwrap()
+                .as_slice(),
+            metadata
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a Linux `org.freedesktop.secrets` provider exposed through `factorseal serve`
- implement plain and standard DH/AES Secret Service sessions, collections, items, prompts, locking, search, create, update, and delete
- bind cryptographic sessions to D-Bus connections and reusable approval grants to the verified Linux process instance plus individual item
- store Secret Service labels and attributes in an authenticated, encrypted vault index
- import existing CLI entries when clients search for an exact `service + username`
- rewrite the README around backup-ready multifactor enrollment and document the Linux provider's current behavior and limitations

## Why

FactorSeal needs to mediate ordinary Linux keyring access without requiring application-specific integrations. Implementing the standard Secret Service API lets libsecret and compatible keyring libraries use the vault while FactorSeal retains control over user approval and grant scope.

## User and developer impact

`factorseal serve` now claims `org.freedesktop.secrets` and presents approvals in its controlling terminal. Approved reads and updates are seamless for the same running process during the configured lease, even when its keyring library reconnects to D-Bus. Create and delete operations use prompt objects, and another existing Secret Service owner must be stopped first.

The current approval UI uses `/dev/tty`; desktop and fingerprint-backed approval remain follow-up work before installing this as a headless D-Bus-activated service.

## Validation

- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --all-features` (17 tests)
- `cargo doc --all-features --no-deps` with rustdoc warnings denied
- formatting and `git diff --check`
- live private-session-bus smoke test using a real `dbus-secret-service` DH/AES client
- live reconnect test confirming the same process reuses its item grant without another read prompt
