### PR TITLE
Add secret references and a volatile session collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ any one enrolled authenticator
        |
 reconstruct one vault key
        |
-get(service, account) -> secret
+get(item, field?) -> secret
 ```
 
 Every completed vault must have at least two independent authenticators
@@ -43,6 +43,35 @@ or fingerprints, or implement atomic authenticator replacement.
 Until the new format is implemented, the commands and APIs in the repository
 retain their version 2 behavior. The target CLI examples below are a design
 contract, not yet available commands.
+
+## Secret references
+
+FactorSeal implements the `item` and optional `field` coordinates from
+[SecretSpec references](https://secretspec.dev/concepts/references/). They are
+the stable identity of a stored secret:
+
+```rust
+use factorseal::{ReferenceOptions, SecretReference};
+
+let reference = SecretReference::with_field("production/database", "password")?;
+vault.set_by_reference_with_options(
+    &reference,
+    b"secret",
+    ReferenceOptions {
+        evict_at: None,
+        service: Some("postgres".into()),
+        account: Some("app".into()),
+    },
+)?;
+let secret = vault.get_by_reference(&reference)?;
+```
+
+`service` and `account` are optional, additional keyring metadata. They are
+kept in a separate encrypted index and can change without changing the
+reference, entry path, or authenticated storage identity. The existing
+`set(service, account, ...)` and `get(service, account)` APIs remain as a
+compatibility view over that metadata. Existing version 1/2 entries are
+migrated to opaque references when rewritten or explicitly resolved.
 
 ## One identity, multiple authenticators
 
@@ -173,9 +202,10 @@ so credential entries do not need to be rewritten and an old authenticator
 envelope cannot participate in the current unlock policy.
 
 XChaCha20-Poly1305 encrypts every credential independently with the reconstructed
-256-bit vault key. Credential service and account names are authenticated and
-hashed for their storage paths. An unlocked session retains only the zeroizing
-vault key, not a plaintext credential cache.
+256-bit vault key. Secret `item` and optional `field` coordinates are
+authenticated and hashed for their storage paths. Keyring service/account
+metadata is stored in a separate authenticated, encrypted index. An unlocked
+session retains only the zeroizing vault key, not a plaintext credential cache.
 
 ## Authenticator providers
 
@@ -251,8 +281,8 @@ explicitly designed policy.
 
 ## Credential storage and sessions
 
-Applications address credentials by the familiar `service + account`
-identity:
+Keyring applications can continue to address credentials through the familiar
+`service + account` compatibility view:
 
 ```rust
 use factorseal::{FactorSealStore, Vault};
@@ -334,6 +364,13 @@ plain and standard DH/AES sessions, the default collection, item search,
 creation, updates, deletion, locking, and prompts. This lets applications that
 already use libsecret, the Secret Service API, or a compatible language
 keyring use FactorSeal without application-specific integration.
+
+The provider exposes two fixed collections. `default` stores encrypted,
+hardware-bound entries in the persistent FactorSeal vault. `session` stores
+secret values only in zeroizing process memory; it never writes them to the
+vault or its Secret Service index. Session items are wiped when the agent locks
+or exits, including at the vault idle deadline. Unrecognized collection aliases
+resolve to `/` as required by the Secret Service API.
 
 Run it in a terminal after stopping any other process that owns
 `org.freedesktop.secrets`:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,9 @@ encryption recipients.
 ```text
 application
     |
-keyring-core: service + account
+item + optional field
+    |
+keyring metadata: service + account
     |
 unlocked FactorSeal session
     |               \
@@ -50,12 +52,19 @@ can additionally require physical presence.
 
 ## Credential storage
 
-Each `(service, account)` pair maps to one file beneath `entries/`. The filename
-is a SHA-256 digest, so user-controlled names cannot escape the vault.
+Each reference, consisting of a required `item` and optional `field`, maps to
+one file beneath `entries/`. The filename is a SHA-256 digest, so
+user-controlled names cannot escape the vault.
 
 XChaCha20-Poly1305 encrypts every value with a fresh 192-bit nonce. The vault
-ID, service, and account are authenticated as associated data. Moving an entry
-to a different name or vault therefore fails authentication.
+ID, item, and optional field are authenticated as associated data. Moving an
+entry to a different reference or vault therefore fails authentication.
+
+Keyring service/account pairs are additional metadata in a separately
+authenticated, encrypted reference index. They can be changed without moving
+the entry or changing its cryptographic identity. Legacy entries whose paths
+were derived from service/account remain readable and migrate to opaque
+references when rewritten or explicitly resolved.
 
 On Unix, FactorSeal creates vault directories with mode `0700`, creates the
 initial configuration with mode `0600`, and refuses to open a vault directory
@@ -66,6 +75,12 @@ that is accessible to group or other users.
 With the `keyring` feature, the keyring adapter owns an unlocked vault. It
 holds one vault key but no decrypted credential cache. Every `get` performs a
 fresh authenticated decryption and returns only the requested value.
+
+The Linux Secret Service provider keeps its `default` and `session`
+collections in separate stores. Default items use the persistent encrypted
+vault. Session item values use zeroizing in-memory buffers and are never added
+to the vault or its encrypted metadata index. Clearing the session store drops
+and zeroizes every value without modifying persistent items.
 
 The CLI currently starts a new session for each invocation. A desktop unlock
 agent is planned to provide an “authorize once” experience across processes.

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,6 +60,12 @@ pub enum Error {
     #[error("credential account must not be empty")]
     EmptyAccount,
 
+    #[error("secret reference item must not be empty")]
+    EmptyReferenceItem,
+
+    #[error("secret reference field must not be empty")]
+    EmptyReferenceField,
+
     #[error("credential {field} is longer than {maximum} bytes")]
     CredentialNameTooLong { field: &'static str, maximum: usize },
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,10 @@ mod error;
 mod vault;
 
 pub use error::{Error, Result};
-pub use vault::{CredentialMetadata, CredentialOptions, UnlockedVault, Vault, VaultInfo};
+pub use vault::{
+    CredentialMetadata, CredentialOptions, ReferenceOptions, SecretReference, UnlockedVault, Vault,
+    VaultInfo,
+};
 
 #[cfg(feature = "hardware")]
 mod hardware;

--- a/src/secret_service.rs
+++ b/src/secret_service.rs
@@ -23,19 +23,24 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use zeroize::Zeroizing;
 
-use crate::{CredentialMetadata, CredentialOptions, Error as VaultError, UnlockedVault};
+use crate::{
+    CredentialMetadata, Error as VaultError, ReferenceOptions, SecretReference, UnlockedVault,
+};
 
 const BUS_NAME: &str = "org.freedesktop.secrets";
 const SERVICE_PATH: &str = "/org/freedesktop/secrets";
 const COLLECTION_PATH: &str = "/org/freedesktop/secrets/collection/factorseal";
+const SESSION_COLLECTION_PATH: &str = "/org/freedesktop/secrets/collection/session";
 const DEFAULT_ALIAS_PATH: &str = "/org/freedesktop/secrets/aliases/default";
+const SESSION_ALIAS_PATH: &str = "/org/freedesktop/secrets/aliases/session";
 const SESSION_PREFIX: &str = "/org/freedesktop/secrets/session/s";
 const PROMPT_PREFIX: &str = "/org/freedesktop/secrets/prompt/p";
 const ITEM_PREFIX: &str = "/org/freedesktop/secrets/collection/factorseal/";
+const SESSION_ITEM_PREFIX: &str = "/org/freedesktop/secrets/collection/session/";
 const ROOT_PATH: &str = "/";
-const COLLECTION_RESOURCE: &str = "*";
 const INDEX_FORMAT: &str = "factorseal-secret-service-metadata";
-const INDEX_VERSION: u32 = 1;
+const LEGACY_INDEX_VERSION: u32 = 1;
+const INDEX_VERSION: u32 = 2;
 const ITEM_LABEL: &str = "org.freedesktop.Secret.Item.Label";
 const ITEM_ATTRIBUTES: &str = "org.freedesktop.Secret.Item.Attributes";
 const COLLECTION_LABEL: &str = "org.freedesktop.Secret.Collection.Label";
@@ -103,6 +108,7 @@ pub enum SecretServiceError {
 /// The caller must unlock the vault before starting the provider. Secret
 /// Service sessions and grants are still scoped to each application's unique
 /// D-Bus connection.
+#[allow(clippy::too_many_lines)]
 pub fn serve_secret_service(
     vault: UnlockedVault,
     options: SecretServiceOptions,
@@ -131,19 +137,42 @@ pub fn serve_secret_service(
     crossroads.insert(
         COLLECTION_PATH,
         &[interfaces.collection],
-        CollectionObject(Arc::clone(&agent)),
+        CollectionObject {
+            agent: Arc::clone(&agent),
+            collection: CollectionKind::Persistent,
+        },
     );
     crossroads.insert(
         DEFAULT_ALIAS_PATH,
         &[interfaces.collection],
-        CollectionObject(Arc::clone(&agent)),
+        CollectionObject {
+            agent: Arc::clone(&agent),
+            collection: CollectionKind::Persistent,
+        },
+    );
+    crossroads.insert(
+        SESSION_COLLECTION_PATH,
+        &[interfaces.collection],
+        CollectionObject {
+            agent: Arc::clone(&agent),
+            collection: CollectionKind::Session,
+        },
+    );
+    crossroads.insert(
+        SESSION_ALIAS_PATH,
+        &[interfaces.collection],
+        CollectionObject {
+            agent: Arc::clone(&agent),
+            collection: CollectionKind::Session,
+        },
     );
     for id in agent.item_ids()? {
         crossroads.insert(
-            item_path(&id),
+            item_path(CollectionKind::Persistent, &id),
             &[interfaces.item],
             ItemObject {
                 agent: Arc::clone(&agent),
+                collection: CollectionKind::Persistent,
                 id,
             },
         );
@@ -188,23 +217,32 @@ pub fn serve_secret_service(
                     PromptCompletion::dismissed(event.prompt_id)
                 }
             };
-            if let Some(item) = &completion.created {
+            if let Some((collection, item)) = &completion.created {
                 lock(&crossroads)?.insert(
-                    item_path(&item.id),
+                    item_path(*collection, &item.id),
                     &[interfaces.item],
                     ItemObject {
                         agent: Arc::clone(&agent),
+                        collection: *collection,
                         id: item.id.clone(),
                     },
                 );
                 connection
-                    .send(collection_signal("ItemCreated", item_path(&item.id)))
+                    .send(collection_signal(
+                        *collection,
+                        "ItemCreated",
+                        item_path(*collection, &item.id),
+                    ))
                     .map_err(|()| dbus::Error::new_failed("failed to send ItemCreated"))?;
             }
-            if let Some(id) = &completion.deleted {
-                let _ = lock(&crossroads)?.remove::<ItemObject>(&item_path(id));
+            if let Some((collection, id)) = &completion.deleted {
+                let _ = lock(&crossroads)?.remove::<ItemObject>(&item_path(*collection, id));
                 connection
-                    .send(collection_signal("ItemDeleted", item_path(id)))
+                    .send(collection_signal(
+                        *collection,
+                        "ItemDeleted",
+                        item_path(*collection, id),
+                    ))
                     .map_err(|()| dbus::Error::new_failed("failed to send ItemDeleted"))?;
             }
             connection
@@ -218,10 +256,14 @@ pub fn serve_secret_service(
 struct ServiceObject(Arc<Agent>);
 
 #[derive(Clone)]
-struct CollectionObject(Arc<Agent>);
+struct CollectionObject {
+    agent: Arc<Agent>,
+    collection: CollectionKind,
+}
 
 struct ItemObject {
     agent: Arc<Agent>,
+    collection: CollectionKind,
     id: String,
 }
 
@@ -234,6 +276,23 @@ struct PromptObject {
     agent: Arc<Agent>,
     id: u64,
     owner: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum CollectionKind {
+    Persistent,
+    Session,
+}
+
+impl CollectionKind {
+    const ALL: [Self; 2] = [Self::Persistent, Self::Session];
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Persistent => "FactorSeal",
+            Self::Session => "Session",
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -256,6 +315,35 @@ impl Default for Index {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct IndexItem {
     id: String,
+    reference: SecretReference,
+    label: String,
+    attributes: HashMap<String, String>,
+    content_type: String,
+    item_type: String,
+    created: u64,
+    modified: u64,
+}
+
+#[derive(Default)]
+struct SessionStore {
+    items: HashMap<String, SessionItem>,
+}
+
+struct SessionItem {
+    metadata: IndexItem,
+    secret: Zeroizing<Vec<u8>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct LegacyIndex {
+    format: String,
+    version: u32,
+    items: Vec<LegacyIndexItem>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct LegacyIndexItem {
+    id: String,
     service: String,
     account: String,
     label: String,
@@ -266,11 +354,73 @@ struct IndexItem {
     modified: u64,
 }
 
+fn load_index(vault: &UnlockedVault) -> Result<(Index, bool), SecretServiceError> {
+    let Some(bytes) = vault.read_secret_service_index()? else {
+        return Ok((Index::default(), false));
+    };
+    let header: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|error| SecretServiceError::InvalidIndex(error.to_string()))?;
+    let format = header.get("format").and_then(serde_json::Value::as_str);
+    let version = header.get("version").and_then(serde_json::Value::as_u64);
+    if format != Some(INDEX_FORMAT) {
+        return Err(SecretServiceError::InvalidIndex(
+            "unsupported format".to_owned(),
+        ));
+    }
+
+    match version {
+        Some(version) if version == u64::from(INDEX_VERSION) => {
+            let index: Index = serde_json::from_slice(&bytes)
+                .map_err(|error| SecretServiceError::InvalidIndex(error.to_string()))?;
+            Ok((index, false))
+        }
+        Some(version) if version == u64::from(LEGACY_INDEX_VERSION) => {
+            let legacy: LegacyIndex = serde_json::from_slice(&bytes)
+                .map_err(|error| SecretServiceError::InvalidIndex(error.to_string()))?;
+            if legacy.format != INDEX_FORMAT || legacy.version != LEGACY_INDEX_VERSION {
+                return Err(SecretServiceError::InvalidIndex(
+                    "unsupported format or version".to_owned(),
+                ));
+            }
+            let mut items = Vec::with_capacity(legacy.items.len());
+            for item in legacy.items {
+                let reference = match vault.resolve_reference(&item.service, &item.account) {
+                    Ok(reference) => reference,
+                    Err(VaultError::NoEntry) => SecretReference::new(item.id.clone())?,
+                    Err(error) => return Err(error.into()),
+                };
+                items.push(IndexItem {
+                    id: item.id,
+                    reference,
+                    label: item.label,
+                    attributes: item.attributes,
+                    content_type: item.content_type,
+                    item_type: item.item_type,
+                    created: item.created,
+                    modified: item.modified,
+                });
+            }
+            Ok((
+                Index {
+                    format: INDEX_FORMAT.to_owned(),
+                    version: INDEX_VERSION,
+                    items,
+                },
+                true,
+            ))
+        }
+        _ => Err(SecretServiceError::InvalidIndex(
+            "unsupported version".to_owned(),
+        )),
+    }
+}
+
 struct Agent {
     vault: Arc<UnlockedVault>,
     index: Mutex<Index>,
+    session_store: Mutex<SessionStore>,
     sessions: Mutex<HashMap<String, Session>>,
-    grants: Mutex<HashMap<(String, String), Instant>>,
+    grants: Mutex<HashMap<(String, GrantResource), Instant>>,
     prompts: Mutex<HashMap<u64, PendingPrompt>>,
     identities: Mutex<HashMap<String, CallerIdentity>>,
     next_id: AtomicU64,
@@ -292,6 +442,12 @@ enum SessionCipher {
     Dh(Zeroizing<[u8; AES_KEY_BYTES]>),
 }
 
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+enum GrantResource {
+    Collection(CollectionKind),
+    Item(CollectionKind, String),
+}
+
 #[derive(Clone, Debug)]
 struct CallerIdentity {
     bus_name: String,
@@ -311,17 +467,35 @@ enum PromptAction {
         objects: Vec<PromptObjectRef>,
     },
     Create {
+        collection: CollectionKind,
         item: Box<IndexItem>,
         secret: Zeroizing<Vec<u8>>,
     },
     Delete {
+        collection: CollectionKind,
         id: String,
     },
 }
 
 enum PromptObjectRef {
-    Collection,
-    Item(String),
+    Collection(CollectionKind),
+    Item(CollectionKind, String),
+}
+
+impl PromptObjectRef {
+    fn resource(&self) -> GrantResource {
+        match self {
+            Self::Collection(collection) => GrantResource::Collection(*collection),
+            Self::Item(collection, id) => GrantResource::Item(*collection, id.clone()),
+        }
+    }
+
+    fn path(&self) -> Path<'static> {
+        match self {
+            Self::Collection(collection) => collection_path(*collection),
+            Self::Item(collection, id) => item_path(*collection, id),
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -340,8 +514,8 @@ struct PromptCompletion {
     prompt_id: u64,
     dismissed: bool,
     result: CompletionResult,
-    created: Option<IndexItem>,
-    deleted: Option<String>,
+    created: Option<(CollectionKind, IndexItem)>,
+    deleted: Option<(CollectionKind, String)>,
 }
 
 impl PromptCompletion {
@@ -378,22 +552,16 @@ impl Agent {
         approval_sender: mpsc::Sender<ApprovalEvent>,
     ) -> Result<Self, SecretServiceError> {
         let vault = Arc::new(vault);
-        let index = match vault.read_secret_service_index()? {
-            Some(bytes) => {
-                let parsed: Index = serde_json::from_slice(&bytes)
-                    .map_err(|error| SecretServiceError::InvalidIndex(error.to_string()))?;
-                if parsed.format != INDEX_FORMAT || parsed.version != INDEX_VERSION {
-                    return Err(SecretServiceError::InvalidIndex(
-                        "unsupported format or version".to_owned(),
-                    ));
-                }
-                parsed
-            }
-            None => Index::default(),
-        };
+        let (index, migrated) = load_index(&vault)?;
+        if migrated {
+            let bytes = serde_json::to_vec(&index)
+                .map_err(|error| SecretServiceError::InvalidIndex(error.to_string()))?;
+            vault.write_secret_service_index(&bytes)?;
+        }
         Ok(Self {
             vault,
             index: Mutex::new(index),
+            session_store: Mutex::new(SessionStore::default()),
             sessions: Mutex::new(HashMap::new()),
             grants: Mutex::new(HashMap::new()),
             prompts: Mutex::new(HashMap::new()),
@@ -415,50 +583,75 @@ impl Agent {
     fn expire_idle_vault(&self) -> Result<bool, SecretServiceError> {
         let expired = lock(&self.last_vault_activity)?.elapsed() >= self.options.vault_idle_timeout;
         if expired {
+            self.clear_session_store()?;
             self.vault.lock()?;
         }
         Ok(expired)
     }
 
-    fn vault_get(&self, service: &str, account: &str) -> Result<Zeroizing<Vec<u8>>, VaultError> {
+    fn clear_session_store(&self) -> Result<(), SecretServiceError> {
+        lock(&self.session_store)?.items.clear();
+        lock(&self.grants)?.retain(|(_, resource), _| match resource {
+            GrantResource::Collection(collection) | GrantResource::Item(collection, _) => {
+                *collection != CollectionKind::Session
+            }
+        });
+        Ok(())
+    }
+
+    fn vault_get(&self, reference: &SecretReference) -> Result<Zeroizing<Vec<u8>>, VaultError> {
         self.record_vault_activity();
-        self.vault.get(service, account)
+        self.vault.get_by_reference(reference)
     }
 
     fn vault_get_with_metadata(
         &self,
-        service: &str,
-        account: &str,
+        reference: &SecretReference,
     ) -> Result<(Zeroizing<Vec<u8>>, CredentialMetadata), VaultError> {
         self.record_vault_activity();
-        self.vault.get_with_metadata(service, account)
+        self.vault.get_by_reference_with_metadata(reference)
     }
 
-    fn vault_set(&self, service: &str, account: &str, secret: &[u8]) -> Result<(), VaultError> {
+    fn vault_set(&self, reference: &SecretReference, secret: &[u8]) -> Result<(), VaultError> {
         self.record_vault_activity();
-        self.vault.set(service, account, secret)
+        self.vault.set_by_reference(reference, secret)
     }
 
     fn vault_set_with_options(
         &self,
-        service: &str,
-        account: &str,
+        reference: &SecretReference,
         secret: &[u8],
-        options: CredentialOptions,
+        options: ReferenceOptions,
     ) -> Result<(), VaultError> {
         self.record_vault_activity();
         self.vault
-            .set_with_options(service, account, secret, options)
+            .set_by_reference_with_options(reference, secret, options)
     }
 
-    fn vault_delete(&self, service: &str, account: &str) -> Result<(), VaultError> {
+    fn vault_delete(&self, reference: &SecretReference) -> Result<(), VaultError> {
         self.record_vault_activity();
-        self.vault.delete(service, account)
+        self.vault.delete_by_reference(reference)
     }
 
-    fn vault_contains(&self, service: &str, account: &str) -> Result<bool, VaultError> {
+    fn vault_contains(&self, reference: &SecretReference) -> Result<bool, VaultError> {
         self.record_vault_activity();
-        self.vault.contains(service, account)
+        self.vault.contains_reference(reference)
+    }
+
+    fn vault_resolve(&self, service: &str, account: &str) -> Result<SecretReference, VaultError> {
+        self.record_vault_activity();
+        self.vault.resolve_reference(service, account)
+    }
+
+    fn vault_update_keyring_metadata(
+        &self,
+        reference: &SecretReference,
+        service: Option<&str>,
+        account: Option<&str>,
+    ) -> Result<(), VaultError> {
+        self.record_vault_activity();
+        self.vault
+            .update_reference_keyring_metadata(reference, service, account)
     }
 
     fn vault_write_index(&self, plaintext: &[u8]) -> Result<(), VaultError> {
@@ -509,35 +702,37 @@ impl Agent {
 
     fn decrypt_secret(
         &self,
-        secret: &Secret,
+        secret: Secret,
         owner: &str,
-    ) -> Result<Zeroizing<Vec<u8>>, MethodErr> {
+    ) -> Result<(Zeroizing<Vec<u8>>, String), MethodErr> {
+        let (session_path, parameters, value, content_type) = secret;
         let sessions = lock_method(&self.sessions)?;
-        let path_key = secret.0.to_string();
+        let path_key = session_path.to_string();
         let session = sessions
             .get(&path_key)
-            .ok_or_else(|| no_session(&secret.0))?;
+            .ok_or_else(|| no_session(&session_path))?;
         ensure_owner(&session.owner, owner)?;
-        match &session.cipher {
+        let plaintext = match &session.cipher {
             SessionCipher::Plain => {
-                if !secret.1.is_empty() {
+                if !parameters.is_empty() {
                     return Err(MethodErr::invalid_arg(&"plain session parameters"));
                 }
-                Ok(Zeroizing::new(secret.2.clone()))
+                Zeroizing::new(value)
             }
             SessionCipher::Dh(key) => {
-                if secret.1.len() != AES_BLOCK_BYTES {
+                if parameters.len() != AES_BLOCK_BYTES {
                     return Err(MethodErr::invalid_arg(&"AES initialization vector"));
                 }
                 let plaintext = cbc::Decryptor::<aes::Aes128>::new(
                     key.as_ref().into(),
-                    secret.1.as_slice().into(),
+                    parameters.as_slice().into(),
                 )
-                .decrypt_padded_vec_mut::<Pkcs7>(&secret.2)
+                .decrypt_padded_vec_mut::<Pkcs7>(&value)
                 .map_err(|_| MethodErr::invalid_arg(&"encrypted Secret payload"))?;
-                Ok(Zeroizing::new(plaintext))
+                Zeroizing::new(plaintext)
             }
-        }
+        };
+        Ok((plaintext, content_type))
     }
 
     fn encrypt_secret(
@@ -571,7 +766,29 @@ impl Agent {
         }
     }
 
-    fn search(&self, attributes: &HashMap<String, String>) -> Result<Vec<IndexItem>, MethodErr> {
+    fn search(
+        &self,
+        collection: CollectionKind,
+        attributes: &HashMap<String, String>,
+    ) -> Result<Vec<IndexItem>, MethodErr> {
+        match collection {
+            CollectionKind::Persistent => self.search_persistent(attributes),
+            CollectionKind::Session => {
+                let store = lock_method(&self.session_store)?;
+                Ok(store
+                    .items
+                    .values()
+                    .filter(|item| attributes_match(&item.metadata.attributes, attributes))
+                    .map(|item| item.metadata.clone())
+                    .collect())
+            }
+        }
+    }
+
+    fn search_persistent(
+        &self,
+        attributes: &HashMap<String, String>,
+    ) -> Result<Vec<IndexItem>, MethodErr> {
         let mut index = lock_method(&self.index)?;
         self.prune_missing_items_method(&mut index)?;
         let mut matches: Vec<_> = index
@@ -587,52 +804,70 @@ impl Agent {
                     .get("username")
                     .or_else(|| attributes.get("account")),
             ) {
-                if self
-                    .vault_contains(service, account)
-                    .map_err(vault_method)?
-                {
-                    let now = unix_time();
-                    let item = IndexItem {
-                        id: random_id().map_err(vault_method)?,
-                        service: service.clone(),
-                        account: account.clone(),
-                        label: format!("{service}: {account}"),
-                        attributes: attributes.clone(),
-                        content_type: "application/octet-stream".to_owned(),
-                        item_type: "org.freedesktop.Secret.Generic".to_owned(),
-                        created: now,
-                        modified: now,
-                    };
-                    index.items.push(item.clone());
-                    self.save_index(&index)?;
-                    matches.push(item);
+                match self.vault_resolve(service, account) {
+                    Ok(reference) => {
+                        let now = unix_time();
+                        let item = IndexItem {
+                            id: random_id().map_err(vault_method)?,
+                            reference,
+                            label: format!("{service}: {account}"),
+                            attributes: attributes.clone(),
+                            content_type: "application/octet-stream".to_owned(),
+                            item_type: "org.freedesktop.Secret.Generic".to_owned(),
+                            created: now,
+                            modified: now,
+                        };
+                        index.items.push(item.clone());
+                        self.save_index(&index)?;
+                        matches.push(item);
+                    }
+                    Err(VaultError::NoEntry) => {}
+                    Err(error) => return Err(vault_method(error)),
                 }
             }
         }
         Ok(matches)
     }
 
-    fn item(&self, id: &str) -> Result<IndexItem, MethodErr> {
-        let mut index = lock_method(&self.index)?;
-        self.prune_missing_items_method(&mut index)?;
-        index
-            .items
-            .iter()
-            .find(|item| item.id == id)
-            .cloned()
-            .ok_or_else(|| no_item(id))
+    fn item(&self, collection: CollectionKind, id: &str) -> Result<IndexItem, MethodErr> {
+        match collection {
+            CollectionKind::Persistent => {
+                let mut index = lock_method(&self.index)?;
+                self.prune_missing_items_method(&mut index)?;
+                index
+                    .items
+                    .iter()
+                    .find(|item| item.id == id)
+                    .cloned()
+                    .ok_or_else(|| no_item(id))
+            }
+            CollectionKind::Session => lock_method(&self.session_store)?
+                .items
+                .get(id)
+                .map(|item| item.metadata.clone())
+                .ok_or_else(|| no_item(id)),
+        }
     }
 
-    fn all_items(&self) -> Result<Vec<IndexItem>, MethodErr> {
-        let mut index = lock_method(&self.index)?;
-        self.prune_missing_items_method(&mut index)?;
-        Ok(index.items.clone())
+    fn all_items(&self, collection: CollectionKind) -> Result<Vec<IndexItem>, MethodErr> {
+        match collection {
+            CollectionKind::Persistent => {
+                let mut index = lock_method(&self.index)?;
+                self.prune_missing_items_method(&mut index)?;
+                Ok(index.items.clone())
+            }
+            CollectionKind::Session => Ok(lock_method(&self.session_store)?
+                .items
+                .values()
+                .map(|item| item.metadata.clone())
+                .collect()),
+        }
     }
 
     fn prune_missing_items(&self, index: &mut Index) -> Result<bool, VaultError> {
         let mut live = Vec::with_capacity(index.items.len());
         for item in &index.items {
-            if self.vault_contains(&item.service, &item.account)? {
+            if self.vault_contains(&item.reference)? {
                 live.push(item.clone());
             }
         }
@@ -657,10 +892,20 @@ impl Agent {
 
     fn set_item_secret(
         &self,
+        collection: CollectionKind,
         id: &str,
         plaintext: &[u8],
         content_type: String,
     ) -> Result<(), MethodErr> {
+        if collection == CollectionKind::Session {
+            let mut store = lock_method(&self.session_store)?;
+            let item = store.items.get_mut(id).ok_or_else(|| no_item(id))?;
+            item.secret = Zeroizing::new(plaintext.to_vec());
+            item.metadata.content_type = content_type;
+            item.metadata.modified = unix_time();
+            return Ok(());
+        }
+
         let mut index = lock_method(&self.index)?;
         let mut updated = index.clone();
         let item = updated
@@ -668,41 +913,156 @@ impl Agent {
             .iter_mut()
             .find(|item| item.id == id)
             .ok_or_else(|| no_item(id))?;
-        let previous = self
-            .vault_get(&item.service, &item.account)
-            .map_err(vault_method)?;
-        let service = item.service.clone();
-        let account = item.account.clone();
+        let previous = self.vault_get(&item.reference).map_err(vault_method)?;
+        let reference = item.reference.clone();
         item.content_type = content_type;
         item.modified = unix_time();
         let bytes = serde_json::to_vec(&updated).map_err(|error| MethodErr::failed(&error))?;
 
-        self.vault_set(&service, &account, plaintext)
+        self.vault_set(&reference, plaintext)
             .map_err(vault_method)?;
         if let Err(error) = self.vault_write_index(&bytes) {
-            let rollback = self.vault_set(&service, &account, &previous);
+            let rollback = self.vault_set(&reference, &previous);
             return Err(transaction_error(&error, rollback.as_ref().err()));
         }
         *index = updated;
         Ok(())
     }
 
-    fn has_grant(&self, owner: &str, resource: &str) -> Result<bool, MethodErr> {
+    fn item_secret(
+        &self,
+        collection: CollectionKind,
+        id: &str,
+    ) -> Result<(Zeroizing<Vec<u8>>, String), MethodErr> {
+        match collection {
+            CollectionKind::Persistent => {
+                let item = self.item(collection, id)?;
+                let secret = self.vault_get(&item.reference).map_err(vault_method)?;
+                Ok((secret, item.content_type))
+            }
+            CollectionKind::Session => {
+                let store = lock_method(&self.session_store)?;
+                let item = store.items.get(id).ok_or_else(|| no_item(id))?;
+                Ok((
+                    Zeroizing::new(item.secret.to_vec()),
+                    item.metadata.content_type.clone(),
+                ))
+            }
+        }
+    }
+
+    fn set_item_attributes(
+        &self,
+        collection: CollectionKind,
+        id: &str,
+        attributes: &HashMap<String, String>,
+    ) -> Result<(), MethodErr> {
+        if collection == CollectionKind::Session {
+            let mut store = lock_method(&self.session_store)?;
+            let item = store.items.get_mut(id).ok_or_else(|| no_item(id))?;
+            item.metadata.attributes.clone_from(attributes);
+            item.metadata.modified = unix_time();
+            return Ok(());
+        }
+
+        let mut index = lock_method(&self.index)?;
+        let mut updated = index.clone();
+        let item = updated
+            .items
+            .iter_mut()
+            .find(|item| item.id == id)
+            .ok_or_else(|| no_item(id))?;
+        let previous_attributes = item.attributes.clone();
+        let reference = item.reference.clone();
+        item.attributes.clone_from(attributes);
+        item.modified = unix_time();
+        let (service, account) = keyring_metadata(attributes);
+        self.vault_update_keyring_metadata(&reference, service, account)
+            .map_err(vault_method)?;
+        if let Err(error) = self.save_index(&updated) {
+            let (previous_service, previous_account) = keyring_metadata(&previous_attributes);
+            let rollback =
+                self.vault_update_keyring_metadata(&reference, previous_service, previous_account);
+            return match rollback {
+                Ok(()) => Err(error),
+                Err(rollback) => Err(MethodErr::failed(&format!(
+                    "{error}; keyring metadata rollback also failed: {rollback}"
+                ))),
+            };
+        }
+        *index = updated;
+        Ok(())
+    }
+
+    fn set_item_label(
+        &self,
+        collection: CollectionKind,
+        id: &str,
+        label: &str,
+    ) -> Result<(), MethodErr> {
+        self.update_item_metadata(collection, id, |item| label.clone_into(&mut item.label))
+    }
+
+    fn set_item_type(
+        &self,
+        collection: CollectionKind,
+        id: &str,
+        item_type: &str,
+    ) -> Result<(), MethodErr> {
+        self.update_item_metadata(collection, id, |item| {
+            item_type.clone_into(&mut item.item_type);
+        })
+    }
+
+    fn update_item_metadata(
+        &self,
+        collection: CollectionKind,
+        id: &str,
+        update: impl FnOnce(&mut IndexItem),
+    ) -> Result<(), MethodErr> {
+        match collection {
+            CollectionKind::Persistent => {
+                let mut index = lock_method(&self.index)?;
+                let item = index
+                    .items
+                    .iter_mut()
+                    .find(|item| item.id == id)
+                    .ok_or_else(|| no_item(id))?;
+                update(item);
+                item.modified = unix_time();
+                self.save_index(&index)
+            }
+            CollectionKind::Session => {
+                let mut store = lock_method(&self.session_store)?;
+                let item = store.items.get_mut(id).ok_or_else(|| no_item(id))?;
+                update(&mut item.metadata);
+                item.metadata.modified = unix_time();
+                Ok(())
+            }
+        }
+    }
+
+    fn has_grant(&self, owner: &str, resource: &GrantResource) -> Result<bool, MethodErr> {
         let now = Instant::now();
         let subject = self.grant_subject(owner)?;
         let mut grants = lock_method(&self.grants)?;
         grants.retain(|_, expires| *expires > now);
-        Ok(grants.contains_key(&(subject.clone(), resource.to_owned()))
-            || grants.contains_key(&(subject, COLLECTION_RESOURCE.to_owned())))
+        let collection = match resource {
+            GrantResource::Collection(collection) | GrantResource::Item(collection, _) => {
+                *collection
+            }
+        };
+        Ok(grants.contains_key(&(subject.clone(), resource.clone()))
+            || grants.contains_key(&(subject, GrantResource::Collection(collection))))
     }
 
-    fn grant(&self, owner: &str, resource: &str) -> Result<(), MethodErr> {
+    fn grant(&self, owner: &str, resource: GrantResource) -> Result<(), MethodErr> {
         let now = Instant::now();
         let subject = self.grant_subject(owner)?;
         let expires = now
             .checked_add(self.options.grant_ttl)
             .ok_or_else(|| MethodErr::failed(&"grant duration is too large"))?;
-        lock_method(&self.grants)?.insert((subject, resource.to_owned()), expires);
+        lock_method(&self.grants)?.insert((subject, resource), expires);
         Ok(())
     }
 
@@ -734,12 +1094,20 @@ impl Agent {
         let mut locked = Vec::new();
         for object in objects {
             match parse_object_path(object)? {
-                PromptObjectRef::Collection => {
-                    grants.retain(|(grant_subject, _), _| grant_subject != &subject);
+                PromptObjectRef::Collection(collection) => {
+                    grants.retain(|(grant_subject, resource), _| {
+                        grant_subject != &subject
+                            || match resource {
+                                GrantResource::Collection(grant_collection)
+                                | GrantResource::Item(grant_collection, _) => {
+                                    *grant_collection != collection
+                                }
+                            }
+                    });
                     locked.push(object.clone());
                 }
-                PromptObjectRef::Item(id) => {
-                    grants.remove(&(subject.clone(), id));
+                PromptObjectRef::Item(collection, id) => {
+                    grants.remove(&(subject.clone(), GrantResource::Item(collection, id)));
                     locked.push(object.clone());
                 }
             }
@@ -887,84 +1255,53 @@ impl Agent {
             PromptAction::Unlock { objects } => {
                 let mut paths = Vec::new();
                 for object in objects {
-                    match object {
-                        PromptObjectRef::Collection => {
-                            self.grant(&prompt.owner, COLLECTION_RESOURCE)
-                                .map_err(method_service)?;
-                            paths.push(collection_path());
-                        }
-                        PromptObjectRef::Item(id) => {
-                            self.grant(&prompt.owner, &id).map_err(method_service)?;
-                            paths.push(item_path(&id));
-                        }
-                    }
+                    self.grant(&prompt.owner, object.resource())
+                        .map_err(method_service)?;
+                    paths.push(object.path());
                 }
                 CompletionResult::Paths(paths)
             }
-            PromptAction::Create { item, secret } => {
-                let previous = match self.vault_get_with_metadata(&item.service, &item.account) {
-                    Ok(value) => Some(value),
-                    Err(VaultError::NoEntry) => None,
-                    Err(error) => return Err(error.into()),
-                };
-                let mut index = lock(&self.index)?;
-                let mut updated = index.clone();
-                if let Some(existing) = updated.items.iter_mut().find(|value| value.id == item.id) {
-                    existing.clone_from(&item);
-                } else {
-                    updated.items.push((*item).clone());
+            PromptAction::Create {
+                collection,
+                item,
+                secret,
+            } => {
+                match collection {
+                    CollectionKind::Persistent => {
+                        self.complete_persistent_create(&item, &secret)?;
+                    }
+                    CollectionKind::Session => {
+                        lock(&self.session_store)?.items.insert(
+                            item.id.clone(),
+                            SessionItem {
+                                metadata: (*item).clone(),
+                                secret,
+                            },
+                        );
+                    }
                 }
-                let bytes = serde_json::to_vec(&updated)
-                    .map_err(|error| SecretServiceError::InvalidIndex(error.to_string()))?;
-
-                self.vault_set(&item.service, &item.account, &secret)?;
-                if let Err(error) = self.vault_write_index(&bytes) {
-                    let rollback = restore_entry(
-                        self,
-                        &item.service,
-                        &item.account,
-                        previous
-                            .as_ref()
-                            .map(|(secret, metadata)| (secret.as_slice(), *metadata)),
-                    );
-                    return Err(service_transaction_error(&error, rollback.as_ref().err()));
-                }
-                *index = updated;
-                self.grant(&prompt.owner, &item.id)
-                    .map_err(method_service)?;
-                created = Some((*item).clone());
-                CompletionResult::Path(item_path(&item.id))
+                self.grant(
+                    &prompt.owner,
+                    GrantResource::Item(collection, item.id.clone()),
+                )
+                .map_err(method_service)?;
+                created = Some((collection, (*item).clone()));
+                CompletionResult::Path(item_path(collection, &item.id))
             }
-            PromptAction::Delete { id } => {
-                let mut index = lock(&self.index)?;
-                let item = index
-                    .items
-                    .iter()
-                    .find(|item| item.id == id)
-                    .cloned()
-                    .ok_or_else(|| {
-                        SecretServiceError::InvalidIndex(format!("unknown item {id}"))
-                    })?;
-                let previous = self.vault_get_with_metadata(&item.service, &item.account)?;
-                let mut updated = index.clone();
-                updated.items.retain(|item| item.id != id);
-                let bytes = serde_json::to_vec(&updated)
-                    .map_err(|error| SecretServiceError::InvalidIndex(error.to_string()))?;
-
-                self.vault_delete(&item.service, &item.account)?;
-                if let Err(error) = self.vault_write_index(&bytes) {
-                    let rollback = self.vault_set_with_options(
-                        &item.service,
-                        &item.account,
-                        &previous.0,
-                        CredentialOptions {
-                            evict_at: previous.1.evict_at,
-                        },
-                    );
-                    return Err(service_transaction_error(&error, rollback.as_ref().err()));
+            PromptAction::Delete { collection, id } => {
+                match collection {
+                    CollectionKind::Persistent => self.complete_persistent_delete(&id)?,
+                    CollectionKind::Session => {
+                        if lock(&self.session_store)?.items.remove(&id).is_none() {
+                            return Err(SecretServiceError::InvalidIndex(format!(
+                                "unknown session item {id}"
+                            )));
+                        }
+                    }
                 }
-                *index = updated;
-                deleted = Some(id);
+                let deleted_resource = GrantResource::Item(collection, id.clone());
+                lock(&self.grants)?.retain(|(_, resource), _| resource != &deleted_resource);
+                deleted = Some((collection, id));
                 CompletionResult::Empty
             }
         };
@@ -977,41 +1314,102 @@ impl Agent {
         }))
     }
 
+    fn complete_persistent_create(
+        &self,
+        item: &IndexItem,
+        secret: &[u8],
+    ) -> Result<(), SecretServiceError> {
+        let previous = match self.vault_get_with_metadata(&item.reference) {
+            Ok(value) => Some(value),
+            Err(VaultError::NoEntry) => None,
+            Err(error) => return Err(error.into()),
+        };
+        let mut index = lock(&self.index)?;
+        let mut updated = index.clone();
+        if let Some(existing) = updated.items.iter_mut().find(|value| value.id == item.id) {
+            existing.clone_from(item);
+        } else {
+            updated.items.push(item.clone());
+        }
+        let bytes = serde_json::to_vec(&updated)
+            .map_err(|error| SecretServiceError::InvalidIndex(error.to_string()))?;
+
+        self.vault_set_with_options(
+            &item.reference,
+            secret,
+            reference_options(
+                &item.attributes,
+                previous
+                    .as_ref()
+                    .and_then(|(_, metadata)| metadata.evict_at),
+            ),
+        )?;
+        if let Err(error) = self.vault_write_index(&bytes) {
+            let rollback = restore_entry(
+                self,
+                &item.reference,
+                previous
+                    .as_ref()
+                    .map(|(secret, metadata)| (secret.as_slice(), metadata.clone())),
+            );
+            return Err(service_transaction_error(&error, rollback.as_ref().err()));
+        }
+        *index = updated;
+        Ok(())
+    }
+
+    fn complete_persistent_delete(&self, id: &str) -> Result<(), SecretServiceError> {
+        let mut index = lock(&self.index)?;
+        let item = index
+            .items
+            .iter()
+            .find(|item| item.id == id)
+            .cloned()
+            .ok_or_else(|| SecretServiceError::InvalidIndex(format!("unknown item {id}")))?;
+        let previous = self.vault_get_with_metadata(&item.reference)?;
+        let mut updated = index.clone();
+        updated.items.retain(|item| item.id != id);
+        let bytes = serde_json::to_vec(&updated)
+            .map_err(|error| SecretServiceError::InvalidIndex(error.to_string()))?;
+
+        self.vault_delete(&item.reference)?;
+        if let Err(error) = self.vault_write_index(&bytes) {
+            let rollback = self.vault_set_with_options(
+                &item.reference,
+                &previous.0,
+                ReferenceOptions {
+                    evict_at: previous.1.evict_at,
+                    service: previous.1.service,
+                    account: previous.1.account,
+                },
+            );
+            return Err(service_transaction_error(&error, rollback.as_ref().err()));
+        }
+        *index = updated;
+        Ok(())
+    }
+
     fn action_summary(&self, action: &PromptAction) -> String {
         match action {
             PromptAction::Unlock { objects } => {
                 if objects
                     .iter()
-                    .any(|object| matches!(object, PromptObjectRef::Collection))
+                    .any(|object| matches!(object, PromptObjectRef::Collection(_)))
                 {
-                    return "access all secrets in the FactorSeal collection".to_owned();
+                    return "access all secrets in a requested collection".to_owned();
                 }
-                let labels = self
-                    .index
-                    .lock()
-                    .ok()
-                    .map(|index| {
-                        objects
-                            .iter()
-                            .filter_map(|object| {
-                                let PromptObjectRef::Item(id) = object else {
-                                    return None;
-                                };
-                                index
-                                    .items
-                                    .iter()
-                                    .find(|item| item.id == *id)
-                                    .map(|item| {
-                                        format!(
-                                            "'{}' ({} / {})",
-                                            item.label, item.service, item.account
-                                        )
-                                    })
-                                    .or_else(|| Some(id.clone()))
-                            })
-                            .collect::<Vec<_>>()
+                let labels = objects
+                    .iter()
+                    .filter_map(|object| {
+                        let PromptObjectRef::Item(collection, id) = object else {
+                            return None;
+                        };
+                        self.item(*collection, id)
+                            .ok()
+                            .map(|item| item_summary(&item))
+                            .or_else(|| Some(id.clone()))
                     })
-                    .unwrap_or_default();
+                    .collect::<Vec<_>>();
                 format!(
                     "read or update {} requested secret(s): {}",
                     labels.len(),
@@ -1019,24 +1417,12 @@ impl Agent {
                 )
             }
             PromptAction::Create { item, .. } => {
-                format!(
-                    "store secret '{}' for {} / {}",
-                    item.label, item.service, item.account
-                )
+                format!("store secret {}", item_summary(item))
             }
-            PromptAction::Delete { id } => self
-                .index
-                .lock()
-                .ok()
-                .and_then(|index| {
-                    index.items.iter().find(|item| item.id == *id).map(|item| {
-                        format!(
-                            "delete secret '{}' for {} / {}",
-                            item.label, item.service, item.account
-                        )
-                    })
-                })
-                .unwrap_or_else(|| format!("delete secret {id}")),
+            PromptAction::Delete { collection, id } => self.item(*collection, id).ok().map_or_else(
+                || format!("delete secret {id}"),
+                |item| format!("delete secret {}", item_summary(&item)),
+            ),
         }
     }
 }
@@ -1097,8 +1483,10 @@ fn register_interfaces(crossroads: &mut Crossroads) -> Interfaces {
                 .data_mut::<ItemObject>(context.path())
                 .ok_or_else(|| MethodErr::no_path(context.path()))?;
             let agent = Arc::clone(&object.agent);
+            let collection = object.collection;
             let id = object.id.clone();
-            let (prompt_id, path) = agent.create_prompt(&owner, PromptAction::Delete { id })?;
+            let (prompt_id, path) =
+                agent.create_prompt(&owner, PromptAction::Delete { collection, id })?;
             crossroads.insert(
                 path.clone(),
                 &[prompt_for_item],
@@ -1116,17 +1504,15 @@ fn register_interfaces(crossroads: &mut Crossroads) -> Interfaces {
             ("secret",),
             |context, object: &mut ItemObject, (session,): (Path<'static>,)| {
                 let owner = sender(context)?;
-                if !object.agent.has_grant(&owner, &object.id)? {
+                let resource = GrantResource::Item(object.collection, object.id.clone());
+                if !object.agent.has_grant(&owner, &resource)? {
                     return Err(is_locked());
                 }
-                let item = object.agent.item(&object.id)?;
-                let secret = object
-                    .agent
-                    .vault_get(&item.service, &item.account)
-                    .map_err(vault_method)?;
+                let (secret, content_type) =
+                    object.agent.item_secret(object.collection, &object.id)?;
                 Ok((object
                     .agent
-                    .encrypt_secret(&session, &owner, &secret, item.content_type)?,))
+                    .encrypt_secret(&session, &owner, &secret, content_type)?,))
             },
         );
         builder.method(
@@ -1135,90 +1521,74 @@ fn register_interfaces(crossroads: &mut Crossroads) -> Interfaces {
             (),
             |context, object: &mut ItemObject, (secret,): (Secret,)| {
                 let owner = sender(context)?;
-                if !object.agent.has_grant(&owner, &object.id)? {
+                let resource = GrantResource::Item(object.collection, object.id.clone());
+                if !object.agent.has_grant(&owner, &resource)? {
                     return Err(is_locked());
                 }
-                let plaintext = object.agent.decrypt_secret(&secret, &owner)?;
-                object
-                    .agent
-                    .set_item_secret(&object.id, &plaintext, secret.3)
+                let (plaintext, content_type) = object.agent.decrypt_secret(secret, &owner)?;
+                object.agent.set_item_secret(
+                    object.collection,
+                    &object.id,
+                    &plaintext,
+                    content_type,
+                )
             },
         );
         builder
             .property::<bool, _>("Locked")
             .get(|context, object| {
                 let owner = property_sender(context)?;
-                Ok(!object.agent.has_grant(&owner, &object.id)?)
+                let resource = GrantResource::Item(object.collection, object.id.clone());
+                Ok(!object.agent.has_grant(&owner, &resource)?)
             });
         builder
             .property::<HashMap<String, String>, _>("Attributes")
-            .get(|_, object| Ok(object.agent.item(&object.id)?.attributes))
+            .get(|_, object| Ok(object.agent.item(object.collection, &object.id)?.attributes))
             .set(|context, object, attributes| {
                 let owner = property_sender(context)?;
-                if !object.agent.has_grant(&owner, &object.id)? {
+                let resource = GrantResource::Item(object.collection, object.id.clone());
+                if !object.agent.has_grant(&owner, &resource)? {
                     return Err(is_locked());
                 }
-                let mut index = lock_method(&object.agent.index)?;
-                let item = index
-                    .items
-                    .iter_mut()
-                    .find(|item| item.id == object.id)
-                    .ok_or_else(|| no_item(&object.id))?;
-                let (service, account) = storage_names(&attributes, &item.id)?;
-                if service != item.service || account != item.account {
-                    return Err(MethodErr::failed(
-                        &"changing service or username is not supported",
-                    ));
-                }
-                item.attributes.clone_from(&attributes);
-                item.modified = unix_time();
-                object.agent.save_index(&index)?;
+                object
+                    .agent
+                    .set_item_attributes(object.collection, &object.id, &attributes)?;
                 Ok(Some(attributes))
             });
         builder
             .property::<String, _>("Label")
-            .get(|_, object| Ok(object.agent.item(&object.id)?.label))
+            .get(|_, object| Ok(object.agent.item(object.collection, &object.id)?.label))
             .set(|context, object, label| {
                 let owner = property_sender(context)?;
-                if !object.agent.has_grant(&owner, &object.id)? {
+                let resource = GrantResource::Item(object.collection, object.id.clone());
+                if !object.agent.has_grant(&owner, &resource)? {
                     return Err(is_locked());
                 }
-                let mut index = lock_method(&object.agent.index)?;
-                let item = index
-                    .items
-                    .iter_mut()
-                    .find(|item| item.id == object.id)
-                    .ok_or_else(|| no_item(&object.id))?;
-                item.label.clone_from(&label);
-                item.modified = unix_time();
-                object.agent.save_index(&index)?;
+                object
+                    .agent
+                    .set_item_label(object.collection, &object.id, &label)?;
                 Ok(Some(label))
             });
         builder
             .property::<String, _>("Type")
-            .get(|_, object| Ok(object.agent.item(&object.id)?.item_type))
+            .get(|_, object| Ok(object.agent.item(object.collection, &object.id)?.item_type))
             .set(|context, object, item_type| {
                 let owner = property_sender(context)?;
-                if !object.agent.has_grant(&owner, &object.id)? {
+                let resource = GrantResource::Item(object.collection, object.id.clone());
+                if !object.agent.has_grant(&owner, &resource)? {
                     return Err(is_locked());
                 }
-                let mut index = lock_method(&object.agent.index)?;
-                let item = index
-                    .items
-                    .iter_mut()
-                    .find(|item| item.id == object.id)
-                    .ok_or_else(|| no_item(&object.id))?;
-                item.item_type.clone_from(&item_type);
-                item.modified = unix_time();
-                object.agent.save_index(&index)?;
+                object
+                    .agent
+                    .set_item_type(object.collection, &object.id, &item_type)?;
                 Ok(Some(item_type))
             });
         builder
             .property::<u64, _>("Created")
-            .get(|_, object| Ok(object.agent.item(&object.id)?.created));
+            .get(|_, object| Ok(object.agent.item(object.collection, &object.id)?.created));
         builder
             .property::<u64, _>("Modified")
-            .get(|_, object| Ok(object.agent.item(&object.id)?.modified));
+            .get(|_, object| Ok(object.agent.item(object.collection, &object.id)?.modified));
     });
 
     let prompt_for_collection = prompt;
@@ -1230,10 +1600,11 @@ fn register_interfaces(crossroads: &mut Crossroads) -> Interfaces {
             "Delete",
             (),
             ("prompt",),
-            |_, _: &mut CollectionObject, ()| -> Result<(Path<'static>,), MethodErr> {
-                Err(MethodErr::failed(
-                    &"the FactorSeal collection cannot be deleted",
-                ))
+            |_, object: &mut CollectionObject, ()| -> Result<(Path<'static>,), MethodErr> {
+                Err(MethodErr::failed(&format!(
+                    "the {} collection cannot be deleted",
+                    object.collection.label()
+                )))
             },
         );
         builder.method(
@@ -1242,10 +1613,10 @@ fn register_interfaces(crossroads: &mut Crossroads) -> Interfaces {
             ("results",),
             |_, object: &mut CollectionObject, (attributes,): (HashMap<String, String>,)| {
                 let paths: Vec<Path<'static>> = object
-                    .0
-                    .search(&attributes)?
+                    .agent
+                    .search(object.collection, &attributes)?
                     .iter()
-                    .map(|item| item_path(&item.id))
+                    .map(|item| item_path(object.collection, &item.id))
                     .collect();
                 Ok((paths,))
             },
@@ -1259,14 +1630,15 @@ fn register_interfaces(crossroads: &mut Crossroads) -> Interfaces {
                 let object = crossroads
                     .data_mut::<CollectionObject>(context.path())
                     .ok_or_else(|| MethodErr::no_path(context.path()))?;
-                let agent = Arc::clone(&object.0);
-                let plaintext = agent.decrypt_secret(&secret, &owner)?;
+                let agent = Arc::clone(&object.agent);
+                let collection = object.collection;
+                let (plaintext, content_type) = agent.decrypt_secret(secret, &owner)?;
                 let label = prop_cast::<String>(&properties, ITEM_LABEL)
                     .cloned()
                     .ok_or_else(|| MethodErr::invalid_arg(&ITEM_LABEL))?;
                 let attributes = property_string_map(&properties, ITEM_ATTRIBUTES)?;
                 let existing = if replace {
-                    agent.search(&attributes)?.into_iter().next()
+                    agent.search(collection, &attributes)?.into_iter().next()
                 } else {
                     None
                 };
@@ -1274,43 +1646,20 @@ fn register_interfaces(crossroads: &mut Crossroads) -> Interfaces {
                     .as_ref()
                     .map_or_else(random_id, |item| Ok(item.id.clone()))
                     .map_err(vault_method)?;
-                let (service, account) = storage_names(&attributes, &id)?;
-                if let Some(same_entry) = agent
-                    .all_items()?
-                    .into_iter()
-                    .find(|item| item.service == service && item.account == account)
-                {
-                    if replace {
-                        if existing
-                            .as_ref()
-                            .is_none_or(|item| item.id != same_entry.id)
-                        {
-                            return Err(MethodErr::failed(
-                                &"replace attributes resolve to a different existing item",
-                            ));
-                        }
-                    } else {
-                        return Err(MethodErr::failed(
-                            &"FactorSeal already contains this service and account",
-                        ));
-                    }
-                } else if !replace
-                    && agent
-                        .vault_contains(&service, &account)
-                        .map_err(vault_method)?
-                {
-                    return Err(MethodErr::failed(
-                        &"FactorSeal already contains this service and account",
-                    ));
-                }
+                let reference = existing
+                    .as_ref()
+                    .map_or_else(
+                        || SecretReference::new(id.clone()),
+                        |item| Ok(item.reference.clone()),
+                    )
+                    .map_err(vault_method)?;
                 let now = unix_time();
                 let item = IndexItem {
                     id,
-                    service,
-                    account,
+                    reference,
                     label,
                     attributes,
-                    content_type: secret.3,
+                    content_type,
                     item_type: existing.as_ref().map_or_else(
                         || "org.freedesktop.Secret.Generic".to_owned(),
                         |item| item.item_type.clone(),
@@ -1321,6 +1670,7 @@ fn register_interfaces(crossroads: &mut Crossroads) -> Interfaces {
                 let (prompt_id, path) = agent.create_prompt(
                     &owner,
                     PromptAction::Create {
+                        collection,
                         item: Box::new(item),
                         secret: plaintext,
                     },
@@ -1341,21 +1691,22 @@ fn register_interfaces(crossroads: &mut Crossroads) -> Interfaces {
             .property::<Vec<Path<'static>>, _>("Items")
             .get(|_, object| {
                 Ok(object
-                    .0
-                    .all_items()?
+                    .agent
+                    .all_items(object.collection)?
                     .iter()
-                    .map(|item| item_path(&item.id))
+                    .map(|item| item_path(object.collection, &item.id))
                     .collect())
             });
         builder
             .property::<String, _>("Label")
-            .get(|_, _| Ok("FactorSeal".to_owned()))
+            .get(|_, object| Ok(object.collection.label().to_owned()))
             .set(|_, _, _| Err(MethodErr::ro_property(&"Label")));
         builder
             .property::<bool, _>("Locked")
             .get(|context, object| {
                 let owner = property_sender(context)?;
-                Ok(!object.0.has_grant(&owner, COLLECTION_RESOURCE)?)
+                let resource = GrantResource::Collection(object.collection);
+                Ok(!object.agent.has_grant(&owner, &resource)?)
             });
         builder.property::<u64, _>("Created").get(|_, _| Ok(0));
         builder.property::<u64, _>("Modified").get(|_, _| Ok(0));
@@ -1391,9 +1742,18 @@ fn register_interfaces(crossroads: &mut Crossroads) -> Interfaces {
             "CreateCollection",
             ("properties", "alias"),
             ("collection", "prompt"),
-            |_, _: &mut ServiceObject, (properties, _alias): (PropMap, String)| {
+            |_, _: &mut ServiceObject, (properties, alias): (PropMap, String)| {
                 let _ = prop_cast::<String>(&properties, COLLECTION_LABEL);
-                Ok((collection_path(), root_path()))
+                let collection = match alias.as_str() {
+                    "default" => CollectionKind::Persistent,
+                    "session" => CollectionKind::Session,
+                    _ => {
+                        return Err(MethodErr::failed(
+                            &"FactorSeal only provides the default and session collections",
+                        ));
+                    }
+                };
+                Ok((collection_path(collection), root_path()))
             },
         );
         builder.method(
@@ -1404,11 +1764,14 @@ fn register_interfaces(crossroads: &mut Crossroads) -> Interfaces {
                 let owner = sender(context)?;
                 let mut unlocked = Vec::new();
                 let mut locked_items = Vec::new();
-                for item in object.0.search(&attributes)? {
-                    if object.0.has_grant(&owner, &item.id)? {
-                        unlocked.push(item_path(&item.id));
-                    } else {
-                        locked_items.push(item_path(&item.id));
+                for collection in CollectionKind::ALL {
+                    for item in object.0.search(collection, &attributes)? {
+                        let resource = GrantResource::Item(collection, item.id.clone());
+                        if object.0.has_grant(&owner, &resource)? {
+                            unlocked.push(item_path(collection, &item.id));
+                        } else {
+                            locked_items.push(item_path(collection, &item.id));
+                        }
                     }
                 }
                 Ok((unlocked, locked_items))
@@ -1428,11 +1791,7 @@ fn register_interfaces(crossroads: &mut Crossroads) -> Interfaces {
                 let mut pending = Vec::new();
                 for path in paths {
                     let object = parse_object_path(&path)?;
-                    let resource = match &object {
-                        PromptObjectRef::Collection => COLLECTION_RESOURCE,
-                        PromptObjectRef::Item(id) => id,
-                    };
-                    if agent.has_grant(&owner, resource)? {
+                    if agent.has_grant(&owner, &object.resource())? {
                         immediate.push(path);
                     } else {
                         pending.push(object);
@@ -1475,22 +1834,19 @@ fn register_interfaces(crossroads: &mut Crossroads) -> Interfaces {
                 let owner = sender(context)?;
                 let mut secrets = HashMap::new();
                 for path in paths {
-                    let PromptObjectRef::Item(id) = parse_object_path(&path)? else {
+                    let PromptObjectRef::Item(collection, id) = parse_object_path(&path)? else {
                         return Err(MethodErr::invalid_arg(&path));
                     };
-                    if !object.0.has_grant(&owner, &id)? {
+                    let resource = GrantResource::Item(collection, id.clone());
+                    if !object.0.has_grant(&owner, &resource)? {
                         continue;
                     }
-                    let item = object.0.item(&id)?;
-                    let secret = object
-                        .0
-                        .vault_get(&item.service, &item.account)
-                        .map_err(vault_method)?;
+                    let (secret, content_type) = object.0.item_secret(collection, &id)?;
                     secrets.insert(
                         path,
                         object
                             .0
-                            .encrypt_secret(&session, &owner, &secret, item.content_type)?,
+                            .encrypt_secret(&session, &owner, &secret, content_type)?,
                     );
                 }
                 Ok((secrets,))
@@ -1500,22 +1856,21 @@ fn register_interfaces(crossroads: &mut Crossroads) -> Interfaces {
             "ReadAlias",
             ("name",),
             ("collection",),
-            |_, _: &mut ServiceObject, (name,): (String,)| {
-                if name.is_empty() {
-                    Ok((root_path(),))
-                } else if name == "default" {
-                    Ok((default_alias_path(),))
-                } else {
-                    Ok((collection_path(),))
-                }
-            },
+            |_, _: &mut ServiceObject, (name,): (String,)| Ok((alias_path(&name),)),
         );
         builder.method(
             "SetAlias",
             ("name", "collection"),
             (),
-            |_, _: &mut ServiceObject, (_name, collection): (String, Path<'static>)| {
-                if collection != collection_path() && collection != default_alias_path() {
+            |_, _: &mut ServiceObject, (name, collection): (String, Path<'static>)| {
+                let expected = match name.as_str() {
+                    "default" => CollectionKind::Persistent,
+                    "session" => CollectionKind::Session,
+                    _ => return Err(MethodErr::invalid_arg(&name)),
+                };
+                if collection != collection_path(expected)
+                    && collection != collection_alias_path(expected)
+                {
                     return Err(MethodErr::invalid_arg(&collection));
                 }
                 Ok(())
@@ -1523,7 +1878,12 @@ fn register_interfaces(crossroads: &mut Crossroads) -> Interfaces {
         );
         builder
             .property::<Vec<Path<'static>>, _>("Collections")
-            .get(|_, _| Ok(vec![collection_path()]));
+            .get(|_, _| {
+                Ok(CollectionKind::ALL
+                    .into_iter()
+                    .map(collection_path)
+                    .collect())
+            });
     });
 
     Interfaces {
@@ -1565,23 +1925,42 @@ fn attributes_match(item: &HashMap<String, String>, query: &HashMap<String, Stri
         .all(|(key, value)| item.get(key) == Some(value))
 }
 
-fn storage_names(
-    attributes: &HashMap<String, String>,
-    id: &str,
-) -> Result<(String, String), MethodErr> {
+fn keyring_metadata(attributes: &HashMap<String, String>) -> (Option<&str>, Option<&str>) {
     let service = attributes
         .get("service")
-        .cloned()
-        .unwrap_or_else(|| "secret-service".to_owned());
+        .map(String::as_str)
+        .filter(|value| !value.is_empty());
     let account = attributes
         .get("username")
         .or_else(|| attributes.get("account"))
-        .cloned()
-        .unwrap_or_else(|| id.to_owned());
-    if service.is_empty() || account.is_empty() {
-        return Err(MethodErr::invalid_arg(&"empty service or account"));
+        .map(String::as_str)
+        .filter(|value| !value.is_empty());
+    match (service, account) {
+        (Some(service), Some(account)) => (Some(service), Some(account)),
+        _ => (None, None),
     }
-    Ok((service, account))
+}
+
+fn reference_options(
+    attributes: &HashMap<String, String>,
+    evict_at: Option<u64>,
+) -> ReferenceOptions {
+    let (service, account) = keyring_metadata(attributes);
+    ReferenceOptions {
+        evict_at,
+        service: service.map(str::to_owned),
+        account: account.map(str::to_owned),
+    }
+}
+
+fn item_summary(item: &IndexItem) -> String {
+    let (service, account) = keyring_metadata(&item.attributes);
+    match (service, account) {
+        (Some(service), Some(account)) => {
+            format!("'{}' ({service} / {account})", item.label)
+        }
+        _ => format!("'{}' (item {})", item.label, item.reference.item()),
+    }
 }
 
 fn property_string_map(
@@ -1613,11 +1992,25 @@ fn property_string_map(
 fn parse_object_path(path: &Path<'_>) -> Result<PromptObjectRef, MethodErr> {
     let value: &str = path.as_ref();
     if matches!(value, COLLECTION_PATH | DEFAULT_ALIAS_PATH) {
-        return Ok(PromptObjectRef::Collection);
+        return Ok(PromptObjectRef::Collection(CollectionKind::Persistent));
+    }
+    if matches!(value, SESSION_COLLECTION_PATH | SESSION_ALIAS_PATH) {
+        return Ok(PromptObjectRef::Collection(CollectionKind::Session));
     }
     if let Some(id) = value.strip_prefix(ITEM_PREFIX) {
         if !id.is_empty() {
-            return Ok(PromptObjectRef::Item(id.to_owned()));
+            return Ok(PromptObjectRef::Item(
+                CollectionKind::Persistent,
+                id.to_owned(),
+            ));
+        }
+    }
+    if let Some(id) = value.strip_prefix(SESSION_ITEM_PREFIX) {
+        if !id.is_empty() {
+            return Ok(PromptObjectRef::Item(
+                CollectionKind::Session,
+                id.to_owned(),
+            ));
         }
     }
     Err(MethodErr::no_path(path))
@@ -1686,9 +2079,9 @@ fn negotiate_session(
             let private = BigUint::from_bytes_be(&*private_bytes);
             let server_public = two.modpow(&private, &prime);
             let shared = client_public.modpow(&private, &prime);
-            let shared = pad_dh_value(&shared)?;
+            let shared = Zeroizing::new(pad_dh_value(&shared)?);
             let mut key = Zeroizing::new([0_u8; AES_KEY_BYTES]);
-            Hkdf::<Sha256>::new(None, &shared)
+            Hkdf::<Sha256>::new(None, shared.as_slice())
                 .expand(&[], &mut *key)
                 .map_err(|_| MethodErr::failed(&"could not derive Secret Service session key"))?;
             let output = pad_dh_value(&server_public)?;
@@ -1726,12 +2119,16 @@ fn unix_time() -> u64 {
         .as_secs()
 }
 
-fn item_path(id: &str) -> Path<'static> {
-    Path::new(format!("{ITEM_PREFIX}{id}")).expect("hex item id is a valid D-Bus path")
+fn item_path(collection: CollectionKind, id: &str) -> Path<'static> {
+    let prefix = match collection {
+        CollectionKind::Persistent => ITEM_PREFIX,
+        CollectionKind::Session => SESSION_ITEM_PREFIX,
+    };
+    Path::new(format!("{prefix}{id}")).expect("hex item id is a valid D-Bus path")
 }
 
-fn collection_signal(member: &str, item: Path<'static>) -> Message {
-    let path = collection_path();
+fn collection_signal(collection: CollectionKind, member: &str, item: Path<'static>) -> Message {
+    let path = collection_path(collection);
     let interface =
         Interface::new("org.freedesktop.Secret.Collection").expect("valid collection interface");
     let member = Member::new(member.to_owned()).expect("valid collection signal");
@@ -1742,12 +2139,28 @@ fn prompt_path(id: u64) -> Path<'static> {
     Path::new(format!("{PROMPT_PREFIX}{id}")).expect("numeric prompt id is a valid D-Bus path")
 }
 
-fn collection_path() -> Path<'static> {
-    Path::new(COLLECTION_PATH).expect("valid collection path")
+fn collection_path(collection: CollectionKind) -> Path<'static> {
+    let path = match collection {
+        CollectionKind::Persistent => COLLECTION_PATH,
+        CollectionKind::Session => SESSION_COLLECTION_PATH,
+    };
+    Path::new(path).expect("valid collection path")
 }
 
-fn default_alias_path() -> Path<'static> {
-    Path::new(DEFAULT_ALIAS_PATH).expect("valid alias path")
+fn collection_alias_path(collection: CollectionKind) -> Path<'static> {
+    let path = match collection {
+        CollectionKind::Persistent => DEFAULT_ALIAS_PATH,
+        CollectionKind::Session => SESSION_ALIAS_PATH,
+    };
+    Path::new(path).expect("valid alias path")
+}
+
+fn alias_path(name: &str) -> Path<'static> {
+    match name {
+        "default" => collection_alias_path(CollectionKind::Persistent),
+        "session" => collection_alias_path(CollectionKind::Session),
+        _ => root_path(),
+    }
 }
 
 fn root_path() -> Path<'static> {
@@ -1770,21 +2183,21 @@ fn method_service(error: MethodErr) -> SecretServiceError {
 
 fn restore_entry(
     agent: &Agent,
-    service: &str,
-    account: &str,
+    reference: &SecretReference,
     previous: Option<(&[u8], CredentialMetadata)>,
 ) -> Result<(), VaultError> {
     if let Some((previous, metadata)) = previous {
         agent.vault_set_with_options(
-            service,
-            account,
+            reference,
             previous,
-            CredentialOptions {
+            ReferenceOptions {
                 evict_at: metadata.evict_at,
+                service: metadata.service,
+                account: metadata.account,
             },
         )
     } else {
-        match agent.vault_delete(service, account) {
+        match agent.vault_delete(reference) {
             Ok(()) | Err(VaultError::NoEntry) => Ok(()),
             Err(error) => Err(error),
         }
@@ -1860,6 +2273,44 @@ mod tests {
         (directory, Arc::new(agent))
     }
 
+    fn create_item(
+        agent: &Agent,
+        collection: CollectionKind,
+        id: &str,
+        attributes: HashMap<String, String>,
+        secret: &[u8],
+    ) {
+        let now = unix_time();
+        let item = IndexItem {
+            id: id.to_owned(),
+            reference: SecretReference::new(id).unwrap(),
+            label: format!("Test {id}"),
+            attributes,
+            content_type: "text/plain".to_owned(),
+            item_type: "org.freedesktop.Secret.Generic".to_owned(),
+            created: now,
+            modified: now,
+        };
+        let (prompt_id, _) = agent
+            .create_prompt(
+                ":1.10",
+                PromptAction::Create {
+                    collection,
+                    item: Box::new(item),
+                    secret: Zeroizing::new(secret.to_vec()),
+                },
+            )
+            .unwrap();
+        let completion = agent
+            .complete_prompt(ApprovalEvent {
+                prompt_id,
+                approved: true,
+            })
+            .unwrap()
+            .unwrap();
+        assert!(completion.created.is_some());
+    }
+
     #[test]
     fn subset_attribute_matching() {
         let attributes = HashMap::from([
@@ -1878,20 +2329,221 @@ mod tests {
     }
 
     #[test]
-    fn generic_items_get_stable_internal_names() {
-        let (service, account) = storage_names(&HashMap::new(), "abc").unwrap();
-        assert_eq!(service, "secret-service");
-        assert_eq!(account, "abc");
+    fn generic_items_do_not_invent_keyring_metadata() {
+        assert_eq!(keyring_metadata(&HashMap::new()), (None, None));
+    }
+
+    #[test]
+    fn aliases_expose_only_default_and_session_collections() {
+        assert_eq!(
+            alias_path("default"),
+            collection_alias_path(CollectionKind::Persistent)
+        );
+        assert_eq!(
+            alias_path("session"),
+            collection_alias_path(CollectionKind::Session)
+        );
+        assert_eq!(alias_path("unknown"), root_path());
+        assert_eq!(alias_path(""), root_path());
+    }
+
+    #[test]
+    fn item_paths_are_scoped_to_their_collection() {
+        let persistent = item_path(CollectionKind::Persistent, "abc");
+        let session = item_path(CollectionKind::Session, "abc");
+
+        assert_ne!(persistent, session);
+        assert!(matches!(
+            parse_object_path(&persistent).unwrap(),
+            PromptObjectRef::Item(CollectionKind::Persistent, id) if id == "abc"
+        ));
+        assert!(matches!(
+            parse_object_path(&session).unwrap(),
+            PromptObjectRef::Item(CollectionKind::Session, id) if id == "abc"
+        ));
+    }
+
+    #[test]
+    fn session_items_never_touch_the_persistent_vault() {
+        let (_directory, agent) = agent();
+        let attributes = HashMap::from([
+            ("service".to_owned(), "example".to_owned()),
+            ("username".to_owned(), "alice".to_owned()),
+        ]);
+
+        create_item(
+            &agent,
+            CollectionKind::Session,
+            "sessionitem",
+            attributes.clone(),
+            b"temporary",
+        );
+
+        assert_eq!(
+            agent
+                .item_secret(CollectionKind::Session, "sessionitem")
+                .unwrap()
+                .0
+                .as_slice(),
+            b"temporary"
+        );
+        assert_eq!(
+            agent
+                .search(CollectionKind::Session, &attributes)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert!(
+            !agent
+                .vault
+                .contains_reference(&SecretReference::new("sessionitem").unwrap())
+                .unwrap()
+        );
+        assert!(agent.vault.read_secret_service_index().unwrap().is_none());
+    }
+
+    #[test]
+    fn persistent_and_session_items_are_independent() {
+        let (_directory, agent) = agent();
+        let attributes = HashMap::from([
+            ("service".to_owned(), "example".to_owned()),
+            ("username".to_owned(), "alice".to_owned()),
+        ]);
+
+        create_item(
+            &agent,
+            CollectionKind::Persistent,
+            "sameid",
+            attributes.clone(),
+            b"persistent",
+        );
+        create_item(
+            &agent,
+            CollectionKind::Session,
+            "sameid",
+            attributes.clone(),
+            b"temporary",
+        );
+
+        assert_eq!(
+            agent
+                .item_secret(CollectionKind::Persistent, "sameid")
+                .unwrap()
+                .0
+                .as_slice(),
+            b"persistent"
+        );
+        assert_eq!(
+            agent
+                .item_secret(CollectionKind::Session, "sameid")
+                .unwrap()
+                .0
+                .as_slice(),
+            b"temporary"
+        );
+        assert_eq!(
+            agent
+                .search(CollectionKind::Persistent, &attributes)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            agent
+                .search(CollectionKind::Session, &attributes)
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn clearing_session_store_preserves_persistent_items() {
+        let (_directory, agent) = agent();
+        create_item(
+            &agent,
+            CollectionKind::Persistent,
+            "persistentitem",
+            HashMap::new(),
+            b"persistent",
+        );
+        create_item(
+            &agent,
+            CollectionKind::Session,
+            "sessionitem",
+            HashMap::new(),
+            b"temporary",
+        );
+
+        agent.clear_session_store().unwrap();
+
+        assert!(agent.all_items(CollectionKind::Session).unwrap().is_empty());
+        assert_eq!(
+            agent
+                .item_secret(CollectionKind::Persistent, "persistentitem")
+                .unwrap()
+                .0
+                .as_slice(),
+            b"persistent"
+        );
+    }
+
+    #[test]
+    fn replacing_session_item_drops_the_previous_zeroizing_value() {
+        let (_directory, agent) = agent();
+        create_item(
+            &agent,
+            CollectionKind::Session,
+            "sessionitem",
+            HashMap::new(),
+            b"first",
+        );
+        create_item(
+            &agent,
+            CollectionKind::Session,
+            "sessionitem",
+            HashMap::new(),
+            b"second",
+        );
+
+        assert_eq!(agent.all_items(CollectionKind::Session).unwrap().len(), 1);
+        assert_eq!(
+            agent
+                .item_secret(CollectionKind::Session, "sessionitem")
+                .unwrap()
+                .0
+                .as_slice(),
+            b"second"
+        );
     }
 
     #[test]
     fn grants_are_bound_to_the_callers_bus_connection() {
         let (_directory, agent) = agent();
-        agent.grant(":1.10", "item").unwrap();
+        let item = GrantResource::Item(CollectionKind::Persistent, "item".to_owned());
+        let other = GrantResource::Item(CollectionKind::Persistent, "other".to_owned());
+        agent.grant(":1.10", item.clone()).unwrap();
 
-        assert!(agent.has_grant(":1.10", "item").unwrap());
-        assert!(!agent.has_grant(":1.11", "item").unwrap());
-        assert!(!agent.has_grant(":1.10", "other").unwrap());
+        assert!(agent.has_grant(":1.10", &item).unwrap());
+        assert!(!agent.has_grant(":1.11", &item).unwrap());
+        assert!(!agent.has_grant(":1.10", &other).unwrap());
+    }
+
+    #[test]
+    fn collection_grants_do_not_cross_store_boundaries() {
+        let (_directory, agent) = agent();
+        let session_collection = GrantResource::Collection(CollectionKind::Session);
+        let session_item = GrantResource::Item(CollectionKind::Session, "item".to_owned());
+        let persistent_item = GrantResource::Item(CollectionKind::Persistent, "item".to_owned());
+
+        agent.grant(":1.10", session_collection).unwrap();
+
+        assert!(agent.has_grant(":1.10", &session_item).unwrap());
+        assert!(!agent.has_grant(":1.10", &persistent_item).unwrap());
+
+        agent.clear_session_store().unwrap();
+        assert!(!agent.has_grant(":1.10", &session_item).unwrap());
     }
 
     #[test]
@@ -1909,9 +2561,10 @@ mod tests {
         )
         .unwrap();
 
-        agent.grant(":1.10", "item").unwrap();
+        let item = GrantResource::Item(CollectionKind::Persistent, "item".to_owned());
+        agent.grant(":1.10", item.clone()).unwrap();
 
-        assert!(!agent.has_grant(":1.10", "item").unwrap());
+        assert!(!agent.has_grant(":1.10", &item).unwrap());
     }
 
     #[test]
@@ -1928,12 +2581,21 @@ mod tests {
             sender,
         )
         .unwrap();
-        agent.vault_set("service", "account", b"secret").unwrap();
+        let reference = SecretReference::new("item").unwrap();
+        agent.vault_set(&reference, b"secret").unwrap();
+        create_item(
+            &agent,
+            CollectionKind::Session,
+            "sessionitem",
+            HashMap::new(),
+            b"temporary",
+        );
 
         assert!(agent.expire_idle_vault().unwrap());
         assert!(agent.vault.is_locked().unwrap());
+        assert!(agent.all_items(CollectionKind::Session).unwrap().is_empty());
         assert!(matches!(
-            agent.vault_get("service", "account"),
+            agent.vault_get(&reference),
             Err(VaultError::VaultLocked)
         ));
     }
@@ -1956,8 +2618,9 @@ mod tests {
         }
         drop(identities);
 
-        agent.grant(":1.10", "item").unwrap();
-        assert!(agent.has_grant(":1.11", "item").unwrap());
+        let item = GrantResource::Item(CollectionKind::Persistent, "item".to_owned());
+        agent.grant(":1.10", item.clone()).unwrap();
+        assert!(agent.has_grant(":1.11", &item).unwrap());
     }
 
     #[test]
@@ -1970,11 +2633,61 @@ mod tests {
             ("username".to_owned(), "alice".to_owned()),
         ]);
 
-        let found = agent.search(&attributes).unwrap();
+        let found = agent
+            .search(CollectionKind::Persistent, &attributes)
+            .unwrap();
         assert_eq!(found.len(), 1);
-        assert_eq!(found[0].service, "example");
-        assert_eq!(found[0].account, "alice");
+        assert_eq!(
+            agent
+                .vault
+                .get_by_reference(&found[0].reference)
+                .unwrap()
+                .as_slice(),
+            b"secret"
+        );
         assert!(agent.vault.read_secret_service_index().unwrap().is_some());
+    }
+
+    #[test]
+    fn legacy_secret_service_index_migrates_to_references() {
+        let directory = tempfile::tempdir().unwrap();
+        let vault = Vault::create_for_test(directory.path().join("vault")).unwrap();
+        vault.set("example", "alice", b"secret").unwrap();
+        let legacy = LegacyIndex {
+            format: INDEX_FORMAT.to_owned(),
+            version: LEGACY_INDEX_VERSION,
+            items: vec![LegacyIndexItem {
+                id: "abc123".to_owned(),
+                service: "example".to_owned(),
+                account: "alice".to_owned(),
+                label: "Example".to_owned(),
+                attributes: HashMap::from([
+                    ("service".to_owned(), "example".to_owned()),
+                    ("username".to_owned(), "alice".to_owned()),
+                ]),
+                content_type: "text/plain".to_owned(),
+                item_type: "org.freedesktop.Secret.Generic".to_owned(),
+                created: 1,
+                modified: 2,
+            }],
+        };
+        vault
+            .write_secret_service_index(&serde_json::to_vec(&legacy).unwrap())
+            .unwrap();
+        let (sender, _receiver) = mpsc::channel();
+
+        let agent = Agent::new(vault, SecretServiceOptions::default(), sender).unwrap();
+        let item = agent.index.lock().unwrap().items[0].clone();
+
+        assert_eq!(agent.index.lock().unwrap().version, INDEX_VERSION);
+        assert_eq!(
+            agent.vault_get(&item.reference).unwrap().as_slice(),
+            b"secret"
+        );
+        let stored = agent.vault.read_secret_service_index().unwrap().unwrap();
+        let migrated: Index = serde_json::from_slice(&stored).unwrap();
+        assert_eq!(migrated.version, INDEX_VERSION);
+        assert_eq!(migrated.items[0].reference, item.reference);
     }
 
     #[test]
@@ -1985,18 +2698,35 @@ mod tests {
             ("service".to_owned(), "example".to_owned()),
             ("username".to_owned(), "alice".to_owned()),
         ]);
-        assert_eq!(agent.search(&attributes).unwrap().len(), 1);
+        let reference = agent
+            .search(CollectionKind::Persistent, &attributes)
+            .unwrap()[0]
+            .reference
+            .clone();
         agent
             .vault_set_with_options(
-                "example",
-                "alice",
+                &reference,
                 b"secret",
-                CredentialOptions { evict_at: Some(0) },
+                ReferenceOptions {
+                    evict_at: Some(0),
+                    service: Some("example".to_owned()),
+                    account: Some("alice".to_owned()),
+                },
             )
             .unwrap();
 
-        assert!(agent.all_items().unwrap().is_empty());
-        assert!(agent.search(&attributes).unwrap().is_empty());
+        assert!(
+            agent
+                .all_items(CollectionKind::Persistent)
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            agent
+                .search(CollectionKind::Persistent, &attributes)
+                .unwrap()
+                .is_empty()
+        );
         assert!(
             agent
                 .vault

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -4,7 +4,7 @@ use std::fs::{self, File};
 use std::io::{self, Read, Write};
 use std::mem::size_of;
 use std::path::{Path, PathBuf};
-use std::sync::RwLock;
+use std::sync::{Mutex, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(feature = "password")]
@@ -21,16 +21,20 @@ use crate::{Error, Result};
 
 const CONFIG_FILE: &str = "vault.json";
 const ENTRIES_DIRECTORY: &str = "entries";
+const REFERENCE_INDEX_FILE: &str = "reference-index.fseal";
 #[cfg(all(target_os = "linux", feature = "secret-service"))]
 const SECRET_SERVICE_INDEX_FILE: &str = "secret-service-index.fseal";
 const VAULT_FORMAT: &str = "factorseal-vault";
 const ENTRY_FORMAT: &str = "factorseal-entry";
+const REFERENCE_INDEX_FORMAT: &str = "factorseal-reference-index";
 #[cfg(all(target_os = "linux", feature = "secret-service"))]
 const SECRET_SERVICE_INDEX_FORMAT: &str = "factorseal-secret-service-index";
 const CURRENT_VAULT_VERSION: u32 = 2;
 const PASSWORD_VAULT_VERSION: u32 = 1;
 const LEGACY_ENTRY_VERSION: u32 = 1;
 const ENTRY_VERSION: u32 = 2;
+const REFERENCE_ENTRY_VERSION: u32 = 3;
+const REFERENCE_INDEX_VERSION: u32 = 1;
 #[cfg(all(target_os = "linux", feature = "secret-service"))]
 const SECRET_SERVICE_INDEX_VERSION: u32 = 1;
 #[cfg(feature = "password")]
@@ -39,6 +43,7 @@ const VAULT_ID_BYTES: usize = 16;
 const MAX_NAME_BYTES: usize = 1024;
 const MAX_CONFIG_BYTES: u64 = 1024 * 1024;
 const MAX_ENTRY_BYTES: u64 = 96 * 1024 * 1024;
+const MAX_REFERENCE_INDEX_BYTES: u64 = 16 * 1024 * 1024;
 const ENTRY_PAYLOAD_NO_EVICTION: u8 = 0;
 const ENTRY_PAYLOAD_EVICT_AT: u8 = 1;
 const ENTRY_PAYLOAD_EVICT_AT_BYTES: usize = 1 + size_of::<u64>();
@@ -74,11 +79,72 @@ pub struct CredentialOptions {
     pub evict_at: Option<u64>,
 }
 
+/// Options and optional keyring metadata applied through a secret reference.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ReferenceOptions {
+    /// Unix timestamp after which the credential is evicted.
+    pub evict_at: Option<u64>,
+    /// Optional keyring service, supplied together with `account`.
+    pub service: Option<String>,
+    /// Optional keyring account, supplied together with `service`.
+    pub account: Option<String>,
+}
+
+/// Stable coordinates for one secret.
+///
+/// `item` identifies a complete secret value. `field` optionally identifies a
+/// value within a structured item. Keyring `service` and `account` values are
+/// stored separately as searchable metadata and are not part of this identity.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct SecretReference {
+    item: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    field: Option<String>,
+}
+
+impl SecretReference {
+    /// Create a reference to a complete secret item.
+    pub fn new(item: impl Into<String>) -> Result<Self> {
+        let reference = Self {
+            item: item.into(),
+            field: None,
+        };
+        validate_reference(&reference)?;
+        Ok(reference)
+    }
+
+    /// Create a reference to one field within a structured secret item.
+    pub fn with_field(item: impl Into<String>, field: impl Into<String>) -> Result<Self> {
+        let reference = Self {
+            item: item.into(),
+            field: Some(field.into()),
+        };
+        validate_reference(&reference)?;
+        Ok(reference)
+    }
+
+    /// Return the item coordinate.
+    #[must_use]
+    pub fn item(&self) -> &str {
+        &self.item
+    }
+
+    /// Return the optional structured-field coordinate.
+    #[must_use]
+    pub fn field(&self) -> Option<&str> {
+        self.field.as_deref()
+    }
+}
+
 /// Authenticated metadata stored with one credential.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct CredentialMetadata {
     /// Unix timestamp after which the credential is evicted.
     pub evict_at: Option<u64>,
+    /// Optional keyring service associated with the stable reference.
+    pub service: Option<String>,
+    /// Optional keyring account associated with the stable reference.
+    pub account: Option<String>,
 }
 
 /// An unlocked vault session.
@@ -90,6 +156,7 @@ pub struct UnlockedVault {
     root: PathBuf,
     vault_id: [u8; VAULT_ID_BYTES],
     key: RwLock<Option<Zeroizing<[u8; KEY_BYTES]>>>,
+    reference_index: Mutex<()>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -149,6 +216,35 @@ struct EncryptedFile {
     version: u32,
     nonce: String,
     ciphertext: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct ReferenceIndex {
+    format: String,
+    version: u32,
+    entries: Vec<ReferenceIndexEntry>,
+}
+
+impl Default for ReferenceIndex {
+    fn default() -> Self {
+        Self {
+            format: REFERENCE_INDEX_FORMAT.to_owned(),
+            version: REFERENCE_INDEX_VERSION,
+            entries: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct ReferenceIndexEntry {
+    reference: SecretReference,
+    service: String,
+    account: String,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct EntryMetadata {
+    evict_at: Option<u64>,
 }
 
 impl EncryptedFile {
@@ -461,6 +557,7 @@ impl UnlockedVault {
             root: root.to_owned(),
             vault_id,
             key: RwLock::new(Some(key)),
+            reference_index: Mutex::new(()),
         }
     }
 
@@ -485,12 +582,7 @@ impl UnlockedVault {
 
     /// Store or replace one credential, preserving its existing eviction deadline.
     pub fn set(&self, service: &str, account: &str, secret: &[u8]) -> Result<()> {
-        let evict_at = match self.metadata(service, account) {
-            Ok(metadata) => metadata.evict_at,
-            Err(Error::NoEntry) => None,
-            Err(error) => return Err(error),
-        };
-        self.set_with_options(service, account, secret, CredentialOptions { evict_at })
+        self.set_keyring_credential(service, account, secret, None)
     }
 
     /// Store or replace one credential and its eviction policy.
@@ -502,13 +594,7 @@ impl UnlockedVault {
         options: CredentialOptions,
     ) -> Result<()> {
         validate_specifiers(service, account)?;
-        let path = self.entry_path(service, account);
-        let plaintext = encode_entry_payload(secret, options.evict_at);
-        let aad = entry_encryption_aad(&self.vault_id, service, account, ENTRY_VERSION);
-        let entry = self.with_key(|key| {
-            EncryptedFile::encrypt(ENTRY_FORMAT, ENTRY_VERSION, key, &aad, &plaintext)
-        })?;
-        atomic_write(&path, &serialize(&entry, &path)?)
+        self.set_keyring_credential(service, account, secret, Some(options))
     }
 
     /// Retrieve one credential in a zeroizing buffer.
@@ -523,15 +609,32 @@ impl UnlockedVault {
         service: &str,
         account: &str,
     ) -> Result<(Zeroizing<Vec<u8>>, CredentialMetadata)> {
-        let (secret, metadata, path) = self.read_credential(service, account)?;
-        if let Some(deadline) = metadata.evict_at {
-            if deadline <= unix_time()? {
-                drop(secret);
-                remove_expired_entry(&path)?;
-                return Err(Error::NoEntry);
-            }
+        validate_specifiers(service, account)?;
+        let _guard = self
+            .reference_index
+            .lock()
+            .map_err(|_| Error::VaultStatePoisoned)?;
+        let mut index = self.read_reference_index()?;
+        if let Some(reference) = self.live_reference(&mut index, service, account)? {
+            let (secret, metadata, _) = self.read_reference_credential(&reference)?;
+            return Ok((
+                secret,
+                CredentialMetadata {
+                    evict_at: metadata.evict_at,
+                    service: Some(service.to_owned()),
+                    account: Some(account.to_owned()),
+                },
+            ));
         }
-        Ok((secret, metadata))
+        let (secret, metadata, _) = self.read_legacy_credential(service, account)?;
+        Ok((
+            secret,
+            CredentialMetadata {
+                evict_at: metadata.evict_at,
+                service: Some(service.to_owned()),
+                account: Some(account.to_owned()),
+            },
+        ))
     }
 
     /// Retrieve authenticated credential metadata without returning its secret.
@@ -551,13 +654,178 @@ impl UnlockedVault {
         self.set_with_options(service, account, &secret, CredentialOptions { evict_at })
     }
 
-    fn read_credential(
+    /// Store or replace a secret by stable reference, preserving its metadata.
+    pub fn set_by_reference(&self, reference: &SecretReference, secret: &[u8]) -> Result<()> {
+        let options = match self.metadata_by_reference(reference) {
+            Ok(metadata) => ReferenceOptions {
+                evict_at: metadata.evict_at,
+                service: metadata.service,
+                account: metadata.account,
+            },
+            Err(Error::NoEntry) => ReferenceOptions::default(),
+            Err(error) => return Err(error),
+        };
+        self.set_by_reference_with_options(reference, secret, options)
+    }
+
+    /// Store or replace a secret and its optional keyring metadata by reference.
+    pub fn set_by_reference_with_options(
+        &self,
+        reference: &SecretReference,
+        secret: &[u8],
+        options: ReferenceOptions,
+    ) -> Result<()> {
+        validate_reference(reference)?;
+        validate_reference_options(&options)?;
+        let ReferenceOptions {
+            evict_at,
+            service,
+            account,
+        } = options;
+        let _guard = self
+            .reference_index
+            .lock()
+            .map_err(|_| Error::VaultStatePoisoned)?;
+        let mut index = self.read_reference_index()?;
+        let previous = match self.read_reference_credential(reference) {
+            Ok(value) => Some(value),
+            Err(Error::NoEntry) => None,
+            Err(error) => return Err(error),
+        };
+        self.write_reference_credential(reference, secret, evict_at)?;
+
+        let changed = set_reference_metadata(
+            &mut index,
+            reference,
+            service.as_deref(),
+            account.as_deref(),
+        );
+        if changed {
+            if let Err(error) = self.write_reference_index(&index) {
+                restore_reference_entry(self, reference, previous.as_ref())?;
+                return Err(error);
+            }
+        }
+        Ok(())
+    }
+
+    /// Retrieve a secret by stable reference.
+    pub fn get_by_reference(&self, reference: &SecretReference) -> Result<Zeroizing<Vec<u8>>> {
+        self.get_by_reference_with_metadata(reference)
+            .map(|(secret, _)| secret)
+    }
+
+    /// Retrieve a referenced secret and its authenticated metadata.
+    pub fn get_by_reference_with_metadata(
+        &self,
+        reference: &SecretReference,
+    ) -> Result<(Zeroizing<Vec<u8>>, CredentialMetadata)> {
+        validate_reference(reference)?;
+        let (secret, entry_metadata, _) = match self.read_reference_credential(reference) {
+            Ok(value) => value,
+            Err(Error::NoEntry) => {
+                self.remove_reference_metadata(reference)?;
+                return Err(Error::NoEntry);
+            }
+            Err(error) => return Err(error),
+        };
+        let _guard = self
+            .reference_index
+            .lock()
+            .map_err(|_| Error::VaultStatePoisoned)?;
+        let index = self.read_reference_index()?;
+        let metadata = index
+            .entries
+            .iter()
+            .find(|entry| entry.reference == *reference);
+        Ok((
+            secret,
+            CredentialMetadata {
+                evict_at: entry_metadata.evict_at,
+                service: metadata.map(|entry| entry.service.clone()),
+                account: metadata.map(|entry| entry.account.clone()),
+            },
+        ))
+    }
+
+    /// Retrieve metadata for a referenced secret without returning its value.
+    pub fn metadata_by_reference(&self, reference: &SecretReference) -> Result<CredentialMetadata> {
+        self.get_by_reference_with_metadata(reference)
+            .map(|(_, metadata)| metadata)
+    }
+
+    /// Replace a referenced secret's eviction deadline without changing it.
+    pub fn update_reference_eviction(
+        &self,
+        reference: &SecretReference,
+        evict_at: Option<u64>,
+    ) -> Result<()> {
+        let (secret, metadata) = self.get_by_reference_with_metadata(reference)?;
+        self.set_by_reference_with_options(
+            reference,
+            &secret,
+            ReferenceOptions {
+                evict_at,
+                service: metadata.service,
+                account: metadata.account,
+            },
+        )
+    }
+
+    /// Resolve keyring metadata to its stable reference.
+    ///
+    /// A legacy service/account entry is migrated to reference storage when it
+    /// is first resolved through this method.
+    pub fn resolve_reference(&self, service: &str, account: &str) -> Result<SecretReference> {
+        validate_specifiers(service, account)?;
+        let _guard = self
+            .reference_index
+            .lock()
+            .map_err(|_| Error::VaultStatePoisoned)?;
+        let mut index = self.read_reference_index()?;
+        if let Some(reference) = self.live_reference(&mut index, service, account)? {
+            return Ok(reference);
+        }
+
+        let (secret, metadata, legacy_path) = self.read_legacy_credential(service, account)?;
+        let reference = self.new_random_reference()?;
+        self.write_reference_credential(&reference, &secret, metadata.evict_at)?;
+        set_reference_metadata(&mut index, &reference, Some(service), Some(account));
+        if let Err(error) = self.write_reference_index(&index) {
+            remove_entry_if_present(&self.reference_entry_path(&reference))?;
+            return Err(error);
+        }
+        remove_entry_if_present(&legacy_path)?;
+        Ok(reference)
+    }
+
+    /// Change optional keyring metadata without changing reference identity.
+    pub fn update_reference_keyring_metadata(
+        &self,
+        reference: &SecretReference,
+        service: Option<&str>,
+        account: Option<&str>,
+    ) -> Result<()> {
+        validate_reference(reference)?;
+        validate_keyring_metadata(service, account)?;
+        let _guard = self
+            .reference_index
+            .lock()
+            .map_err(|_| Error::VaultStatePoisoned)?;
+        self.read_reference_credential(reference)?;
+        let mut index = self.read_reference_index()?;
+        if set_reference_metadata(&mut index, reference, service, account) {
+            self.write_reference_index(&index)?;
+        }
+        Ok(())
+    }
+
+    fn read_legacy_credential(
         &self,
         service: &str,
         account: &str,
-    ) -> Result<(Zeroizing<Vec<u8>>, CredentialMetadata, PathBuf)> {
-        validate_specifiers(service, account)?;
-        let path = self.entry_path(service, account);
+    ) -> Result<(Zeroizing<Vec<u8>>, EntryMetadata, PathBuf)> {
+        let path = self.legacy_entry_path(service, account);
         let encoded = match read_limited(&path, MAX_ENTRY_BYTES) {
             Ok(value) => value,
             Err(Error::Io { source, .. }) if source.kind() == io::ErrorKind::NotFound => {
@@ -582,21 +850,196 @@ impl UnlockedVault {
             _ => Err(Error::InvalidEntry),
         })?;
         if entry.version == LEGACY_ENTRY_VERSION {
-            return Ok((plaintext, CredentialMetadata::default(), path));
+            return Ok((plaintext, EntryMetadata::default(), path));
         }
         let (secret, metadata) = decode_entry_payload(plaintext)?;
-        Ok((secret, metadata, path))
+        evict_if_expired(secret, metadata, path)
+    }
+
+    fn read_reference_credential(
+        &self,
+        reference: &SecretReference,
+    ) -> Result<(Zeroizing<Vec<u8>>, EntryMetadata, PathBuf)> {
+        validate_reference(reference)?;
+        let path = self.reference_entry_path(reference);
+        let encoded = match read_limited(&path, MAX_ENTRY_BYTES) {
+            Ok(value) => value,
+            Err(Error::Io { source, .. }) if source.kind() == io::ErrorKind::NotFound => {
+                return Err(Error::NoEntry);
+            }
+            Err(error) => return Err(error),
+        };
+        let entry: EncryptedFile = deserialize(&encoded, &path).map_err(|_| Error::InvalidEntry)?;
+        let plaintext = self.with_key(|key| {
+            entry.decrypt(
+                ENTRY_FORMAT,
+                REFERENCE_ENTRY_VERSION,
+                key,
+                &reference_entry_encryption_aad(&self.vault_id, reference, REFERENCE_ENTRY_VERSION),
+            )
+        })?;
+        let (secret, metadata) = decode_entry_payload(plaintext)?;
+        evict_if_expired(secret, metadata, path)
+    }
+
+    fn write_reference_credential(
+        &self,
+        reference: &SecretReference,
+        secret: &[u8],
+        evict_at: Option<u64>,
+    ) -> Result<()> {
+        validate_reference(reference)?;
+        let path = self.reference_entry_path(reference);
+        let plaintext = encode_entry_payload(secret, evict_at);
+        let aad =
+            reference_entry_encryption_aad(&self.vault_id, reference, REFERENCE_ENTRY_VERSION);
+        let entry = self.with_key(|key| {
+            EncryptedFile::encrypt(ENTRY_FORMAT, REFERENCE_ENTRY_VERSION, key, &aad, &plaintext)
+        })?;
+        atomic_write(&path, &serialize(&entry, &path)?)
+    }
+
+    fn set_keyring_credential(
+        &self,
+        service: &str,
+        account: &str,
+        secret: &[u8],
+        options: Option<CredentialOptions>,
+    ) -> Result<()> {
+        validate_specifiers(service, account)?;
+        let _guard = self
+            .reference_index
+            .lock()
+            .map_err(|_| Error::VaultStatePoisoned)?;
+        let mut index = self.read_reference_index()?;
+        if let Some(reference) = self.live_reference(&mut index, service, account)? {
+            let evict_at = match options {
+                Some(options) => options.evict_at,
+                None => self.read_reference_credential(&reference)?.1.evict_at,
+            };
+            return self.write_reference_credential(&reference, secret, evict_at);
+        }
+
+        let legacy = match self.read_legacy_credential(service, account) {
+            Ok(value) => Some(value),
+            Err(Error::NoEntry) => None,
+            Err(error) => return Err(error),
+        };
+        let evict_at = options.map_or_else(
+            || {
+                legacy
+                    .as_ref()
+                    .and_then(|(_, metadata, _)| metadata.evict_at)
+            },
+            |options| options.evict_at,
+        );
+        let reference = self.new_random_reference()?;
+        self.write_reference_credential(&reference, secret, evict_at)?;
+        set_reference_metadata(&mut index, &reference, Some(service), Some(account));
+        if let Err(error) = self.write_reference_index(&index) {
+            remove_entry_if_present(&self.reference_entry_path(&reference))?;
+            return Err(error);
+        }
+        if let Some((_, _, path)) = legacy {
+            remove_entry_if_present(&path)?;
+        }
+        Ok(())
+    }
+
+    fn live_reference(
+        &self,
+        index: &mut ReferenceIndex,
+        service: &str,
+        account: &str,
+    ) -> Result<Option<SecretReference>> {
+        let mut changed = false;
+        loop {
+            let candidate = index
+                .entries
+                .iter()
+                .rev()
+                .find(|entry| entry.service == service && entry.account == account)
+                .map(|entry| entry.reference.clone());
+            let Some(reference) = candidate else {
+                if changed {
+                    self.write_reference_index(index)?;
+                }
+                return Ok(None);
+            };
+            match self.read_reference_credential(&reference) {
+                Ok(_) => {
+                    if changed {
+                        self.write_reference_index(index)?;
+                    }
+                    return Ok(Some(reference));
+                }
+                Err(Error::NoEntry) => {
+                    index.entries.retain(|entry| entry.reference != reference);
+                    changed = true;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    fn new_random_reference(&self) -> Result<SecretReference> {
+        for _ in 0..4 {
+            let mut bytes = [0_u8; 16];
+            getrandom::fill(&mut bytes)?;
+            let reference = SecretReference::new(encode(&bytes))?;
+            if !self.reference_entry_path(&reference).exists() {
+                return Ok(reference);
+            }
+        }
+        Err(Error::Random(
+            "could not allocate a unique secret reference".to_owned(),
+        ))
     }
 
     /// Delete one credential.
     pub fn delete(&self, service: &str, account: &str) -> Result<()> {
         validate_specifiers(service, account)?;
-        let path = self.entry_path(service, account);
-        match fs::remove_file(&path) {
-            Ok(()) => Ok(()),
-            Err(source) if source.kind() == io::ErrorKind::NotFound => Err(Error::NoEntry),
-            Err(source) => Err(Error::Io { path, source }),
+        let _guard = self
+            .reference_index
+            .lock()
+            .map_err(|_| Error::VaultStatePoisoned)?;
+        let mut index = self.read_reference_index()?;
+        if let Some(reference) = self.live_reference(&mut index, service, account)? {
+            return self.delete_reference_locked(&reference, &mut index);
         }
+        remove_entry(&self.legacy_entry_path(service, account))
+    }
+
+    /// Delete a secret by stable reference.
+    pub fn delete_by_reference(&self, reference: &SecretReference) -> Result<()> {
+        validate_reference(reference)?;
+        let _guard = self
+            .reference_index
+            .lock()
+            .map_err(|_| Error::VaultStatePoisoned)?;
+        let mut index = self.read_reference_index()?;
+        self.delete_reference_locked(reference, &mut index)
+    }
+
+    fn delete_reference_locked(
+        &self,
+        reference: &SecretReference,
+        index: &mut ReferenceIndex,
+    ) -> Result<()> {
+        let previous = self.read_reference_credential(reference)?;
+        remove_entry(&previous.2)?;
+        let before = index.entries.len();
+        let original = index.clone();
+        index.entries.retain(|entry| entry.reference != *reference);
+        if index.entries.len() == before {
+            return Ok(());
+        }
+        if let Err(error) = self.write_reference_index(index) {
+            self.write_reference_credential(reference, &previous.0, previous.1.evict_at)?;
+            *index = original;
+            return Err(error);
+        }
+        Ok(())
     }
 
     /// Test whether a non-expired credential exists.
@@ -606,6 +1049,86 @@ impl UnlockedVault {
             Err(Error::NoEntry) => Ok(false),
             Err(error) => Err(error),
         }
+    }
+
+    /// Test whether a non-expired referenced secret exists.
+    pub fn contains_reference(&self, reference: &SecretReference) -> Result<bool> {
+        match self.metadata_by_reference(reference) {
+            Ok(_) => Ok(true),
+            Err(Error::NoEntry) => Ok(false),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn remove_reference_metadata(&self, reference: &SecretReference) -> Result<()> {
+        let _guard = self
+            .reference_index
+            .lock()
+            .map_err(|_| Error::VaultStatePoisoned)?;
+        let mut index = self.read_reference_index()?;
+        let before = index.entries.len();
+        index.entries.retain(|entry| entry.reference != *reference);
+        if index.entries.len() != before {
+            self.write_reference_index(&index)?;
+        }
+        Ok(())
+    }
+
+    fn read_reference_index(&self) -> Result<ReferenceIndex> {
+        let path = self.root.join(REFERENCE_INDEX_FILE);
+        let encoded = match read_limited(&path, MAX_REFERENCE_INDEX_BYTES) {
+            Ok(value) => value,
+            Err(Error::Io { source, .. }) if source.kind() == io::ErrorKind::NotFound => {
+                return Ok(ReferenceIndex::default());
+            }
+            Err(error) => return Err(error),
+        };
+        let encrypted: EncryptedFile =
+            deserialize(&encoded, &path).map_err(|_| Error::InvalidEntry)?;
+        let plaintext = self.with_key(|key| {
+            encrypted.decrypt(
+                REFERENCE_INDEX_FORMAT,
+                REFERENCE_INDEX_VERSION,
+                key,
+                &reference_index_aad(&self.vault_id),
+            )
+        })?;
+        let index: ReferenceIndex =
+            serde_json::from_slice(&plaintext).map_err(|_| Error::InvalidEntry)?;
+        validate_reference_index(&index)?;
+        Ok(index)
+    }
+
+    fn write_reference_index(&self, index: &ReferenceIndex) -> Result<()> {
+        validate_reference_index(index)?;
+        let path = self.root.join(REFERENCE_INDEX_FILE);
+        let plaintext = serialize(index, &path)?;
+        let encrypted = self.with_key(|key| {
+            EncryptedFile::encrypt(
+                REFERENCE_INDEX_FORMAT,
+                REFERENCE_INDEX_VERSION,
+                key,
+                &reference_index_aad(&self.vault_id),
+                &plaintext,
+            )
+        })?;
+        atomic_write(&path, &serialize(&encrypted, &path)?)
+    }
+
+    fn reference_entry_path(&self, reference: &SecretReference) -> PathBuf {
+        let mut hash = Sha256::new();
+        hash.update(reference_entry_aad(&self.vault_id, reference));
+        self.root
+            .join(ENTRIES_DIRECTORY)
+            .join(format!("{}.fseal", hex::encode(hash.finalize())))
+    }
+
+    fn legacy_entry_path(&self, service: &str, account: &str) -> PathBuf {
+        let mut hash = Sha256::new();
+        hash.update(entry_aad(&self.vault_id, service, account));
+        self.root
+            .join(ENTRIES_DIRECTORY)
+            .join(format!("{}.fseal", hex::encode(hash.finalize())))
     }
 
     #[must_use]
@@ -653,14 +1176,6 @@ impl UnlockedVault {
         })?;
         let path = self.root.join(SECRET_SERVICE_INDEX_FILE);
         atomic_write(&path, &serialize(&index, &path)?)
-    }
-
-    fn entry_path(&self, service: &str, account: &str) -> PathBuf {
-        let mut hash = Sha256::new();
-        hash.update(entry_aad(&self.vault_id, service, account));
-        self.root
-            .join(ENTRIES_DIRECTORY)
-            .join(format!("{}.fseal", hex::encode(hash.finalize())))
     }
 }
 
@@ -1059,6 +1574,75 @@ pub(crate) fn validate_specifiers(service: &str, account: &str) -> Result<()> {
     Ok(())
 }
 
+fn validate_reference(reference: &SecretReference) -> Result<()> {
+    if reference.item.is_empty() {
+        return Err(Error::EmptyReferenceItem);
+    }
+    if reference.item.len() > MAX_NAME_BYTES {
+        return Err(Error::CredentialNameTooLong {
+            field: "item",
+            maximum: MAX_NAME_BYTES,
+        });
+    }
+    if let Some(field) = &reference.field {
+        if field.is_empty() {
+            return Err(Error::EmptyReferenceField);
+        }
+        if field.len() > MAX_NAME_BYTES {
+            return Err(Error::CredentialNameTooLong {
+                field: "field",
+                maximum: MAX_NAME_BYTES,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_reference_options(options: &ReferenceOptions) -> Result<()> {
+    validate_keyring_metadata(options.service.as_deref(), options.account.as_deref())
+}
+
+fn validate_keyring_metadata(service: Option<&str>, account: Option<&str>) -> Result<()> {
+    match (service, account) {
+        (Some(service), Some(account)) => validate_specifiers(service, account),
+        (None, None) => Ok(()),
+        _ => Err(Error::InvalidMetadata(
+            "reference service and account must be supplied together".to_owned(),
+        )),
+    }
+}
+
+fn validate_reference_index(index: &ReferenceIndex) -> Result<()> {
+    if index.format != REFERENCE_INDEX_FORMAT || index.version != REFERENCE_INDEX_VERSION {
+        return Err(Error::InvalidMetadata(
+            "unsupported reference index format or version".to_owned(),
+        ));
+    }
+    for entry in &index.entries {
+        validate_reference(&entry.reference)?;
+        validate_specifiers(&entry.service, &entry.account)?;
+    }
+    Ok(())
+}
+
+fn set_reference_metadata(
+    index: &mut ReferenceIndex,
+    reference: &SecretReference,
+    service: Option<&str>,
+    account: Option<&str>,
+) -> bool {
+    let before = index.entries.clone();
+    index.entries.retain(|entry| entry.reference != *reference);
+    if let (Some(service), Some(account)) = (service, account) {
+        index.entries.push(ReferenceIndexEntry {
+            reference: reference.clone(),
+            service: service.to_owned(),
+            account: account.to_owned(),
+        });
+    }
+    index.entries != before
+}
+
 fn validate_vault_directory(path: &Path) -> Result<()> {
     let metadata = match fs::metadata(path) {
         Ok(value) => value,
@@ -1102,6 +1686,36 @@ fn entry_encryption_aad(
 ) -> Vec<u8> {
     let mut aad = entry_aad(vault_id, service, account);
     aad.extend_from_slice(&version.to_be_bytes());
+    aad
+}
+
+fn reference_entry_aad(vault_id: &[u8; VAULT_ID_BYTES], reference: &SecretReference) -> Vec<u8> {
+    let mut aad = b"factorseal/reference-entry/v1\0".to_vec();
+    aad.extend_from_slice(vault_id);
+    append_length_prefixed(&mut aad, reference.item.as_bytes());
+    match &reference.field {
+        Some(field) => {
+            aad.push(1);
+            append_length_prefixed(&mut aad, field.as_bytes());
+        }
+        None => aad.push(0),
+    }
+    aad
+}
+
+fn reference_entry_encryption_aad(
+    vault_id: &[u8; VAULT_ID_BYTES],
+    reference: &SecretReference,
+    version: u32,
+) -> Vec<u8> {
+    let mut aad = reference_entry_aad(vault_id, reference);
+    aad.extend_from_slice(&version.to_be_bytes());
+    aad
+}
+
+fn reference_index_aad(vault_id: &[u8; VAULT_ID_BYTES]) -> Vec<u8> {
+    let mut aad = b"factorseal/reference-index/v1\0".to_vec();
+    aad.extend_from_slice(vault_id);
     aad
 }
 
@@ -1203,7 +1817,7 @@ fn encode_entry_payload(secret: &[u8], evict_at: Option<u64>) -> Zeroizing<Vec<u
 
 fn decode_entry_payload(
     mut payload: Zeroizing<Vec<u8>>,
-) -> Result<(Zeroizing<Vec<u8>>, CredentialMetadata)> {
+) -> Result<(Zeroizing<Vec<u8>>, EntryMetadata)> {
     let (metadata_bytes, evict_at) = match payload.first() {
         Some(&ENTRY_PAYLOAD_NO_EVICTION) => (1, None),
         Some(&ENTRY_PAYLOAD_EVICT_AT) if payload.len() >= ENTRY_PAYLOAD_EVICT_AT_BYTES => {
@@ -1218,7 +1832,22 @@ fn decode_entry_payload(
         _ => return Err(Error::InvalidEntry),
     };
     payload.drain(..metadata_bytes);
-    Ok((payload, CredentialMetadata { evict_at }))
+    Ok((payload, EntryMetadata { evict_at }))
+}
+
+fn evict_if_expired(
+    secret: Zeroizing<Vec<u8>>,
+    metadata: EntryMetadata,
+    path: PathBuf,
+) -> Result<(Zeroizing<Vec<u8>>, EntryMetadata, PathBuf)> {
+    if let Some(deadline) = metadata.evict_at {
+        if deadline <= unix_time()? {
+            drop(secret);
+            remove_expired_entry(&path)?;
+            return Err(Error::NoEntry);
+        }
+    }
+    Ok((secret, metadata, path))
 }
 
 fn remove_expired_entry(path: &Path) -> Result<()> {
@@ -1229,6 +1858,36 @@ fn remove_expired_entry(path: &Path) -> Result<()> {
             path: path.to_owned(),
             source,
         }),
+    }
+}
+
+fn remove_entry(path: &Path) -> Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => Err(Error::NoEntry),
+        Err(source) => Err(Error::Io {
+            path: path.to_owned(),
+            source,
+        }),
+    }
+}
+
+fn remove_entry_if_present(path: &Path) -> Result<()> {
+    match remove_entry(path) {
+        Ok(()) | Err(Error::NoEntry) => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn restore_reference_entry(
+    vault: &UnlockedVault,
+    reference: &SecretReference,
+    previous: Option<&(Zeroizing<Vec<u8>>, EntryMetadata, PathBuf)>,
+) -> Result<()> {
+    if let Some((secret, metadata, _)) = previous {
+        vault.write_reference_credential(reference, secret, metadata.evict_at)
+    } else {
+        remove_entry_if_present(&vault.reference_entry_path(reference))
     }
 }
 
@@ -1400,15 +2059,144 @@ mod tests {
     }
 
     #[test]
+    fn item_and_field_are_stable_reference_coordinates() {
+        let (_directory, _path, vault) = vault();
+        let item = SecretReference::new("database").unwrap();
+        let username = SecretReference::with_field("database", "username").unwrap();
+        let password = SecretReference::with_field("database", "password").unwrap();
+
+        vault.set_by_reference(&item, b"document").unwrap();
+        vault.set_by_reference(&username, b"alice").unwrap();
+        vault.set_by_reference(&password, b"hunter2").unwrap();
+
+        assert_eq!(
+            vault.get_by_reference(&item).unwrap().as_slice(),
+            b"document"
+        );
+        assert_eq!(
+            vault.get_by_reference(&username).unwrap().as_slice(),
+            b"alice"
+        );
+        assert_eq!(
+            vault.get_by_reference(&password).unwrap().as_slice(),
+            b"hunter2"
+        );
+        assert_ne!(
+            vault.reference_entry_path(&item),
+            vault.reference_entry_path(&username)
+        );
+        assert_ne!(
+            vault.reference_entry_path(&username),
+            vault.reference_entry_path(&password)
+        );
+    }
+
+    #[test]
+    fn keyring_metadata_can_change_without_changing_reference_identity() {
+        let (_directory, _path, vault) = vault();
+        let reference = SecretReference::with_field("database", "password").unwrap();
+        vault
+            .set_by_reference_with_options(
+                &reference,
+                b"secret",
+                ReferenceOptions {
+                    evict_at: None,
+                    service: Some("old-service".to_owned()),
+                    account: Some("old-account".to_owned()),
+                },
+            )
+            .unwrap();
+        let path = vault.reference_entry_path(&reference);
+
+        vault
+            .update_reference_keyring_metadata(&reference, Some("new-service"), Some("new-account"))
+            .unwrap();
+
+        assert_eq!(
+            vault.get("new-service", "new-account").unwrap().as_slice(),
+            b"secret"
+        );
+        assert!(matches!(
+            vault.get("old-service", "old-account"),
+            Err(Error::NoEntry)
+        ));
+        assert_eq!(vault.reference_entry_path(&reference), path);
+        assert_eq!(
+            vault.metadata_by_reference(&reference).unwrap(),
+            CredentialMetadata {
+                evict_at: None,
+                service: Some("new-service".to_owned()),
+                account: Some("new-account".to_owned()),
+            }
+        );
+    }
+
+    #[test]
+    fn duplicate_keyring_metadata_resolves_to_the_latest_live_reference() {
+        let (_directory, _path, vault) = vault();
+        let first = SecretReference::new("first").unwrap();
+        let second = SecretReference::new("second").unwrap();
+        let options = || ReferenceOptions {
+            evict_at: None,
+            service: Some("service".to_owned()),
+            account: Some("account".to_owned()),
+        };
+        vault
+            .set_by_reference_with_options(&first, b"first", options())
+            .unwrap();
+        vault
+            .set_by_reference_with_options(&second, b"second", options())
+            .unwrap();
+
+        assert_eq!(
+            vault.get("service", "account").unwrap().as_slice(),
+            b"second"
+        );
+        vault.delete_by_reference(&second).unwrap();
+        assert_eq!(
+            vault.get("service", "account").unwrap().as_slice(),
+            b"first"
+        );
+    }
+
+    #[test]
+    fn keyring_metadata_index_is_encrypted() {
+        let (_directory, _path, vault) = vault();
+        let reference = SecretReference::new("opaque-item").unwrap();
+        vault
+            .set_by_reference_with_options(
+                &reference,
+                b"secret",
+                ReferenceOptions {
+                    evict_at: None,
+                    service: Some("metadata-service-marker".to_owned()),
+                    account: Some("metadata-account-marker".to_owned()),
+                },
+            )
+            .unwrap();
+
+        let stored = fs::read(vault.path().join(REFERENCE_INDEX_FILE)).unwrap();
+        for marker in [
+            b"metadata-service-marker".as_slice(),
+            b"metadata-account-marker".as_slice(),
+            b"opaque-item".as_slice(),
+        ] {
+            assert!(!stored.windows(marker.len()).any(|window| window == marker));
+        }
+    }
+
+    #[test]
     fn entry_names_are_authenticated() {
         let (_directory, _path, vault) = vault();
-        vault.set("service", "first", b"secret").unwrap();
-        let first = vault.entry_path("service", "first");
-        let second = vault.entry_path("service", "second");
+        let first_reference = SecretReference::new("first").unwrap();
+        let second_reference = SecretReference::new("second").unwrap();
+        vault.set_by_reference(&first_reference, b"secret").unwrap();
+        let first = vault.reference_entry_path(&first_reference);
+        let second = vault.reference_entry_path(&second_reference);
         fs::copy(first, second).unwrap();
 
         assert!(matches!(
-            vault.get("service", "second"),
+            vault.get_by_reference(&second_reference),
             Err(Error::Authentication)
         ));
     }
@@ -1416,14 +2204,15 @@ mod tests {
     #[test]
     fn encrypted_entry_envelope_is_validated() {
         let (_directory, _path, vault) = vault();
-        vault.set("service", "account", b"secret").unwrap();
-        let path = vault.entry_path("service", "account");
+        let reference = SecretReference::new("item").unwrap();
+        vault.set_by_reference(&reference, b"secret").unwrap();
+        let path = vault.reference_entry_path(&reference);
         let mut entry: EncryptedFile = deserialize(&fs::read(&path).unwrap(), &path).unwrap();
         entry.version += 1;
         fs::write(&path, serialize(&entry, &path).unwrap()).unwrap();
 
         assert!(matches!(
-            vault.get("service", "account"),
+            vault.get_by_reference(&reference),
             Err(Error::InvalidEntry)
         ));
     }
@@ -1433,7 +2222,7 @@ mod tests {
         let (_directory, _vault_path, vault) = vault();
         let service = "legacy";
         let account = "entry";
-        let path = vault.entry_path(service, account);
+        let path = vault.legacy_entry_path(service, account);
         let aad = entry_aad(&vault.vault_id, service, account);
         let entry = vault
             .with_key(|key| {
@@ -1454,22 +2243,60 @@ mod tests {
         );
         assert_eq!(
             vault.metadata(service, account).unwrap(),
-            CredentialMetadata::default()
+            CredentialMetadata {
+                evict_at: None,
+                service: Some(service.to_owned()),
+                account: Some(account.to_owned()),
+            }
+        );
+    }
+
+    #[test]
+    fn resolving_legacy_keyring_metadata_migrates_to_an_opaque_reference() {
+        let (_directory, _vault_path, vault) = vault();
+        let service = "legacy-service";
+        let account = "legacy-account";
+        let legacy_path = vault.legacy_entry_path(service, account);
+        let plaintext = encode_entry_payload(b"legacy secret", Some(u64::MAX));
+        let aad = entry_encryption_aad(&vault.vault_id, service, account, ENTRY_VERSION);
+        let entry = vault
+            .with_key(|key| {
+                EncryptedFile::encrypt(ENTRY_FORMAT, ENTRY_VERSION, key, &aad, &plaintext)
+            })
+            .unwrap();
+        atomic_write(&legacy_path, &serialize(&entry, &legacy_path).unwrap()).unwrap();
+
+        let reference = vault.resolve_reference(service, account).unwrap();
+
+        assert_ne!(reference.item(), service);
+        assert_eq!(reference.field(), None);
+        assert!(!legacy_path.exists());
+        assert_eq!(
+            vault.get_by_reference(&reference).unwrap().as_slice(),
+            b"legacy secret"
+        );
+        assert_eq!(
+            vault.metadata_by_reference(&reference).unwrap().evict_at,
+            Some(u64::MAX)
         );
     }
 
     #[test]
     fn expired_credentials_are_evicted() {
         let (_directory, _vault_path, vault) = vault();
+        let reference = SecretReference::with_field("database", "password").unwrap();
         vault
-            .set_with_options(
-                "service",
-                "account",
+            .set_by_reference_with_options(
+                &reference,
                 b"secret",
-                CredentialOptions { evict_at: Some(0) },
+                ReferenceOptions {
+                    evict_at: Some(0),
+                    service: Some("service".to_owned()),
+                    account: Some("account".to_owned()),
+                },
             )
             .unwrap();
-        let path = vault.entry_path("service", "account");
+        let path = vault.reference_entry_path(&reference);
 
         assert!(matches!(
             vault.get("service", "account"),
@@ -1477,6 +2304,7 @@ mod tests {
         ));
         assert!(!path.exists());
         assert!(!vault.contains("service", "account").unwrap());
+        assert!(!vault.contains_reference(&reference).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add opaque `SecretReference` coordinates with separately encrypted keyring metadata
- migrate the Secret Service index to reference-backed items while retaining legacy compatibility
- split Secret Service storage into persistent `default` and RAM-only `session` collections
- keep session secret values in zeroizing buffers and clear them on agent/vault teardown
- scope item paths and access grants by collection, and return `/` for unknown aliases

## Why

FactorSeal previously coupled credential identity to keyring service/account metadata and routed every non-default Secret Service alias to persistent storage. That could silently persist values clients deliberately placed in libsecret's session collection. Opaque references make secret identity stable while the separate volatile store preserves the lifetime requested by clients.

## Impact

Persistent credentials remain hardware-bound in the FactorSeal vault. Session credentials are shared for the agent lifetime but never written to vault entries or the encrypted Secret Service index. Existing Secret Service metadata is migrated when loaded, and legacy vault entries remain readable.

## Validation

- `devenv shell cargo test --all-features`
- `devenv shell cargo clippy --all-targets --all-features -- -D warnings`
- `devenv shell cargo fmt --all -- --check`
- `git diff --check`
