### PR TITLE
Add biometric factor support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to FactorSeal will be documented in this file.
   refusing DPAPI and Linux keyring fallback.
 - Add PIN-protected YubiKey PIV 2-of-2 unlock using independent vault-key
   shares.
+- Add optional platform-biometric gating for hardware operations, including
+  biometric + YubiKey composition, and report configured factors through the
+  Rust API and CLI.
 - Make password vault support non-default and add migration from version 1
   password wrapping to version 2 hardware wrapping.
 - Add encrypted credential storage, CLI, and optional `keyring-core` API in a

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ enclave: Apple Secure Enclave on macOS or TPM 2.0 on Windows and Linux. The
 enclave protects one share of the vault key, while a PIN-protected YubiKey
 protects the other. **Two-factor authentication (2FA) is required by design**
 for every supported persistent vault unlock; neither factor can unlock the
-vault alone. FactorSeal can serve Linux applications through the standard
-Secret Service API and supports expiring secrets through per-credential
-eviction deadlines.
+vault alone. On supported platforms, the hardware operation can additionally
+require biometric verification. FactorSeal can serve Linux applications
+through the standard Secret Service API and supports expiring secrets through
+per-credential eviction deadlines.
 
 The prototype still exposes hardware-only and legacy-password compatibility
 paths. They do not satisfy FactorSeal's 2FA design requirement and are not
@@ -55,7 +56,7 @@ credential cache, or an encrypted directory:
 
 | Option | Storage | Interfaces | Unlock | App access | Lock scope | Credential expiry |
 | --- | --- | --- | --- | --- | --- | --- |
-| **FactorSeal** | Encrypted file per entry | CLI, Rust, Secret Service | **2FA:** TPM/Secure Enclave + YubiKey | Per-caller, per-item grants | Vault timer; item/collection locks | **Deletes secret** |
+| **FactorSeal** | Encrypted file per entry | CLI, Rust, Secret Service | **2FA:** TPM/Secure Enclave + YubiKey; optional biometric gate | Per-caller, per-item grants | Vault timer; item/collection locks | **Deletes secret** |
 | **GNOME Keyring** | Encrypted keyring + RAM session | Secret Service/libsecret | Password, often via PAM | Shared by same-user apps | Keyring; logout clears session | None |
 | **KWallet** | Encrypted wallet file | D-Bus/C++ | Password or GPG | Per-app, wallet-wide | Inactivity, screen lock, last app | None |
 | **KeePassXC** | KDBX database | GUI, CLI, browser, Secret Service | Password + optional key/YubiKey | Site rules; optional prompts | Whole database | Marks expired; retains |
@@ -130,9 +131,34 @@ uses a PIN-protected RSA-2048 PIV key in slot `9d`:
 vault key = platform share XOR YubiKey share
 ```
 
-The current prototype supports one YubiKey. Backup authenticators, phones,
-fingerprints, atomic authenticator replacement, and recovery are target
-features rather than implemented guarantees.
+Factor support is capability-based. A factor may protect key material or gate
+another factor's key operation; those are different security properties.
+
+| Factor | Role | Status |
+| --- | --- | --- |
+| Platform hardware | Protects a vault-key share | Implemented; required by version 2 |
+| Biometric | Gates the platform hardware operation | Implemented with `--biometric` where `hardware-enclave` can enforce `BiometricOnly` |
+| YubiKey | Protects an independent share through PIV | Implemented behind `yubikey` |
+| Passkey | Must protect a share with stable WebAuthn PRF/CTAP `hmac-secret` output | Provider planned |
+| Authenticator app | Must release a share through cryptographic challenge-response | Provider planned; ordinary TOTP is not sufficient |
+
+Biometric verification does not create another independently protected share,
+so `hardware + biometric` remains a transitional profile. Combining
+`--biometric` with `--yubikey` retains the 2-of-2 share construction and adds
+biometric verification before the platform share is released. The current
+`hardware-enclave` integration enforces this on macOS and Windows; unsupported
+platforms fail instead of silently dropping the policy.
+
+A conventional six-digit TOTP app cannot independently protect an offline
+vault share: a local verifier would have to retain the TOTP seed, and a copied
+verifier could then calculate the same codes. A future phone provider must
+hold its own key material and answer a vault-bound challenge. Likewise, a
+passkey provider must use stable PRF or `hmac-secret` output; an ordinary
+authentication signature is not treated as a wrapping key.
+
+The current prototype supports one YubiKey. Backup authenticators, passkeys,
+phone challenge-response providers, atomic authenticator replacement, and
+recovery remain target features.
 
 Hardware-only version 2 APIs remain temporarily available for prototype
 development and migration. They do not meet the project's 2FA design
@@ -189,7 +215,9 @@ compatibility view.
 The current version 2 prototype implements:
 
 - vault creation and unlock through the platform hardware enclave;
+- optional platform-biometric gating of hardware unlock on supported systems;
 - single-YubiKey 2-of-2 unlock with platform hardware;
+- provider-neutral factor reporting through the Rust API and CLI status;
 - independently authenticated and encrypted credential entries;
 - SecretSpec `item` and optional `field` references;
 - optional per-credential eviction;
@@ -198,9 +226,9 @@ The current version 2 prototype implements:
   `session` collections;
 - approval grants scoped to one caller and one item.
 
-It does not yet implement independent backup authenticators, phone or
-fingerprint providers, recovery, atomic factor replacement, audit events, or
-rollback protection.
+It does not yet implement independent backup authenticators, passkey or phone
+challenge-response providers, recovery, atomic factor replacement, audit
+events, or rollback protection.
 
 The prototype also retains hardware-only and legacy-password compatibility
 paths. Those paths are implementation gaps relative to the required 2FA design,
@@ -218,6 +246,13 @@ printf 'postgres://localhost/mydb' |
   cargo run --features yubikey -- set my-project DATABASE_URL
 cargo run --features yubikey -- get my-project DATABASE_URL
 cargo run --features yubikey -- status
+```
+
+On macOS or Windows, require platform biometrics in addition to the two
+independently protected shares:
+
+```console
+cargo run --features yubikey -- init --biometric --yubikey
 ```
 
 The default vault location is the platform-specific user-data directory.
@@ -301,7 +336,8 @@ through `FactorSealStoreOptions`.
 
 ## Feature flags
 
-- `hardware` (default): hardware-backed wrapping through `hardware-enclave`.
+- `hardware` (default): hardware-backed wrapping and optional biometric access
+  policy through `hardware-enclave`.
 - `cli` (default): builds the `factorseal` command.
 - `keyring` (default): implements `keyring-core`.
 - `secret-service` (Linux default): provides `org.freedesktop.secrets`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,6 +23,8 @@ must not be treated as supported deployment profiles.
 - Version 2 requires a Secure Enclave or TPM backend and rejects Linux keyring
   and Windows DPAPI fallback.
 - The selected platform backend is recorded and must match at unlock.
+- A configured biometric access policy is recorded and must be enforced again
+  when the platform key is opened; unsupported platforms fail closed.
 - YubiKey two-factor vaults split the key into independently protected random
   shares; both shares are required.
 - Vault-key and credential encryption use XChaCha20-Poly1305.
@@ -37,8 +39,10 @@ must not be treated as supported deployment profiles.
 ## Current limitations
 
 - The CLI and public API still permit creating and unlocking hardware-only
-  version 2 vaults. Removing that transitional path is required before the
-  implementation enforces the 2FA design invariant universally.
+  version 2 vaults, with or without a biometric gate. Biometrics authorize use
+  of the platform key but do not create an independent second key share.
+  Removing those transitional paths is required before the implementation
+  enforces the 2FA design invariant universally.
 - Hardware integrations have not been exercised in this repository's automated
   tests on every supported platform or TPM model.
 - `hardware-enclave` 0.2.10 reports native Linux encryption handles as
@@ -48,6 +52,10 @@ must not be treated as supported deployment profiles.
 - The YubiKey provider supports one pre-provisioned RSA-2048 PIV key in slot
   `9d` on firmware 5.2.3+. It does not provision keys, support backup
   YubiKeys, or provide recovery.
+- Passkey and authenticator-app providers are not implemented. A passkey
+  provider must use stable PRF/`hmac-secret` output, and a phone provider must
+  hold independent key material. TOTP-only verification is not accepted as an
+  offline share-protection mechanism.
 - Losing or resetting the platform hardware or required YubiKey permanently
   loses access unless secrets were separately backed up. A recovery-key export
   is not implemented.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,10 @@ encrypted entry      zeroizing vault key
 
 Version 2 is the current format. Initialization creates a random 256-bit vault
 key and a vault-specific platform key through `hardware-enclave`. The platform
-key encrypts either the complete vault key or one share of it.
+key encrypts either the complete vault key or one share of it. Vault metadata
+records the platform access policy. Existing vaults default to `none`;
+biometric-gated vaults record `biometric` and must reopen the hardware key with
+the same policy.
 
 Version 1 derives a wrapping key from a password with Argon2id. It remains
 readable only when the non-default `password` feature is enabled. Migrating
@@ -55,10 +58,24 @@ slot, algorithm, nonce, and encrypted share. Unlock therefore requires the
 same platform hardware, the selected YubiKey, and its PIN. A PIV touch policy
 can additionally require physical presence.
 
-The version 2 format and public API still contain a hardware-only path for
-prototype development and migration. That transitional path does not meet the
-2FA design requirement and is not a supported deployment profile. Version 1
-password vaults are legacy compatibility only.
+Platform biometric verification is an access policy on the platform hardware
+operation. It gates release of the platform share but does not produce an
+independent share of its own. A `hardware+biometric+yubikey` vault therefore
+keeps the same two independently protected shares and adds a biometric check
+to the platform side. A `hardware+biometric` vault has only one protected key
+share and remains a transitional profile.
+
+Future passkey providers must derive a wrapping key from stable WebAuthn PRF
+or CTAP `hmac-secret` output. Authentication signatures are not assumed to be
+stable key material. Future authenticator-app providers must hold independent
+key material and use vault-bound challenge-response. TOTP verification alone
+cannot protect an offline share because the local verifier would need the
+same TOTP seed.
+
+The version 2 format and public API still contain hardware-only paths, with or
+without a biometric gate, for prototype development and migration. Those
+transitional paths do not meet the 2FA design requirement and are not supported
+deployment profiles. Version 1 password vaults are legacy compatibility only.
 
 ## Credential storage
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -11,9 +11,11 @@ persistent vault. The current policy is 2-of-2: platform hardware protects one
 random share and a PIN-protected YubiKey protects the other. Neither factor
 independently protects the complete vault key.
 
-The prototype retains hardware-only and legacy-password compatibility paths
-for development and migration. They do not satisfy the factor policy and are
-not supported deployment profiles.
+Biometrics are a user-verification gate on a platform key operation, not a
+separate key-share provider. The prototype retains hardware-only, biometric-
+gated hardware-only, and legacy-password compatibility paths for development
+and migration. They do not satisfy the independent-share policy and are not
+supported deployment profiles.
 
 ## Platform hardware
 
@@ -32,6 +34,22 @@ backend is recorded in `vault.json`, and later unlocks must match it.
 
 Native Linux requires the `tpm2-tss` runtime and access to `/dev/tpmrm0`, or a
 reachable `tpm2-abrmd` resource manager.
+
+## Biometric
+
+`init --biometric` configures the platform hardware key with the
+`BiometricOnly` access policy exposed by `hardware-enclave`. The policy is
+stored in `vault.json` and supplied again on every open; a platform that cannot
+enforce it returns an error instead of downgrading to an interaction-free key.
+
+The current dependency supports platform biometric enforcement on macOS and
+Windows. Native Linux does not expose a corresponding hardware-enforced
+biometric policy.
+
+Biometric verification gates the platform share. It does not add an
+independently protected share, so it is an additional check in a compliant
+`hardware+biometric+yubikey` vault and not a replacement for the YubiKey in the
+current 2-of-2 construction.
 
 ## YubiKey
 
@@ -61,6 +79,29 @@ Password support is behind the non-default `password` feature. It exists for:
 It is not added to version 2 as an `any` fallback. Such a fallback would allow
 a copied vault and password to bypass its machine binding.
 
+## Passkeys
+
+Passkeys are a target provider, not an implemented provider. A FactorSeal
+passkey must return stable, credential-bound secret material through WebAuthn
+PRF or CTAP `hmac-secret`, with user presence or verification enforced by the
+authenticator. That output can derive a key that wraps one random vault share.
+
+An ordinary passkey authentication signature is not sufficient. Signatures
+are authentication evidence, may be randomized, and are not a stable secret
+from which the same wrapping key can safely be reconstructed.
+
+## Authenticator apps
+
+A phone authenticator is also a target provider. To meet the provider
+contract, the phone must retain independent key material and release or help
+derive a share only after answering a vault-bound challenge.
+
+Conventional TOTP is deliberately not treated as a share-protecting factor in
+an offline vault. The local verifier would need the TOTP seed in order to
+verify codes; anyone who recovered that verifier state could calculate the
+same codes. TOTP could gate an online, rate-limited service, but that would be
+a different trust and availability model.
+
 ## Provider contract
 
 Unlock providers must:
@@ -74,3 +115,5 @@ Unlock providers must:
 7. Distinguish missing hardware, denied authorization, and backend failures.
 8. Refuse a silent downgrade to a weaker provider.
 9. Support explicit lock and bounded session expiry when the agent is added.
+10. Record whether the factor protects key material or only gates another
+    factor, so the policy cannot count one protected share twice.

--- a/src/bin/factorseal.rs
+++ b/src/bin/factorseal.rs
@@ -7,7 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use clap::{Parser, Subcommand};
 use directories::ProjectDirs;
-use factorseal::{CredentialOptions, Error as VaultError, UnlockedVault, Vault};
+use factorseal::{CredentialOptions, Error as VaultError, FactorKind, UnlockedVault, Vault};
 #[cfg(all(target_os = "linux", feature = "secret-service"))]
 use factorseal::{SecretServiceError, SecretServiceOptions, serve_secret_service};
 use serde::Serialize;
@@ -44,8 +44,12 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
-    /// Create a vault. Supported deployments require --yubikey for 2FA.
+    /// Create a vault with platform hardware and selected factors.
     Init {
+        /// Require platform biometric verification for hardware-key use.
+        #[arg(long)]
+        biometric: bool,
+
         /// Use the required YubiKey PIV second factor in slot 9d.
         #[cfg(feature = "yubikey")]
         #[arg(long)]
@@ -137,8 +141,8 @@ impl Cli {
     fn unlock_vault(&self, path: &Path) -> Result<UnlockedVault, CliError> {
         let info = Vault::info(path)?;
         match info.unlock_method.as_str() {
-            "hardware" => Ok(Vault::unlock(path)?),
-            "hardware+yubikey" => {
+            "hardware" | "hardware+biometric" => Ok(Vault::unlock(path)?),
+            "hardware+yubikey" | "hardware+biometric+yubikey" => {
                 #[cfg(feature = "yubikey")]
                 {
                     let pin = read_yubikey_pin(self.yubikey_pin_file.as_deref())?;
@@ -180,8 +184,8 @@ enum CliError {
     #[error("passwords do not match")]
     PasswordMismatch,
 
-    #[cfg(all(feature = "password", feature = "yubikey"))]
-    #[error("--password and --yubikey cannot be used together")]
+    #[cfg(feature = "password")]
+    #[error("legacy --password cannot be combined with another factor")]
     ConflictingInitFactors,
 
     #[error("I/O error for `{path}`: {source}")]
@@ -216,22 +220,7 @@ fn main() {
 fn run(cli: Cli) -> Result<(), CliError> {
     let vault_path = resolve_vault_path(cli.vault.as_deref())?;
     match &cli.command {
-        Command::Init {
-            #[cfg(feature = "yubikey")]
-            yubikey,
-            #[cfg(feature = "password")]
-            password,
-        } => init_vault(
-            &vault_path,
-            #[cfg(feature = "yubikey")]
-            *yubikey,
-            #[cfg(feature = "password")]
-            *password,
-            #[cfg(feature = "yubikey")]
-            cli.yubikey_pin_file.as_deref(),
-            #[cfg(feature = "password")]
-            cli.password_file.as_deref(),
-        ),
+        Command::Init { .. } => init_vault_from_cli(&cli, &vault_path),
         Command::Set {
             service,
             account,
@@ -318,6 +307,31 @@ fn run(cli: Cli) -> Result<(), CliError> {
     }
 }
 
+fn init_vault_from_cli(cli: &Cli, path: &Path) -> Result<(), CliError> {
+    let Command::Init {
+        biometric,
+        #[cfg(feature = "yubikey")]
+        yubikey,
+        #[cfg(feature = "password")]
+        password,
+    } = &cli.command
+    else {
+        unreachable!("init_vault_from_cli is only called for Command::Init");
+    };
+    init_vault(
+        path,
+        *biometric,
+        #[cfg(feature = "yubikey")]
+        *yubikey,
+        #[cfg(feature = "password")]
+        *password,
+        #[cfg(feature = "yubikey")]
+        cli.yubikey_pin_file.as_deref(),
+        #[cfg(feature = "password")]
+        cli.password_file.as_deref(),
+    )
+}
+
 fn show_status(path: &Path) -> Result<(), CliError> {
     let info = Vault::info(path)?;
     let status = Status {
@@ -325,6 +339,7 @@ fn show_status(path: &Path) -> Result<(), CliError> {
         version: info.version,
         vault_id: info.vault_id,
         unlock_method: info.unlock_method,
+        factors: info.factors,
         hardware_backend: info.hardware_backend,
         yubikey_serial: info.yubikey_serial,
         state: "locked",
@@ -380,11 +395,16 @@ fn resolve_vault_path(explicit: Option<&Path>) -> Result<PathBuf, CliError> {
 
 fn init_vault(
     path: &Path,
+    biometric: bool,
     #[cfg(feature = "yubikey")] yubikey: bool,
     #[cfg(feature = "password")] password: bool,
     #[cfg(feature = "yubikey")] yubikey_pin_file: Option<&Path>,
     #[cfg(feature = "password")] password_file: Option<&Path>,
 ) -> Result<(), CliError> {
+    #[cfg(feature = "password")]
+    if password && biometric {
+        return Err(CliError::ConflictingInitFactors);
+    }
     #[cfg(all(feature = "password", feature = "yubikey"))]
     if password && yubikey {
         return Err(CliError::ConflictingInitFactors);
@@ -402,18 +422,34 @@ fn init_vault(
     #[cfg(feature = "yubikey")]
     if yubikey {
         let pin = read_yubikey_pin(yubikey_pin_file)?;
-        Vault::create_with_yubikey(path, &pin)?;
-        println!(
-            "Initialized hardware + YubiKey FactorSeal vault at {}",
-            path.display()
-        );
+        if biometric {
+            Vault::create_with_biometric_and_yubikey(path, &pin)?;
+            println!(
+                "Initialized biometric-gated hardware + YubiKey FactorSeal vault at {}",
+                path.display()
+            );
+        } else {
+            Vault::create_with_yubikey(path, &pin)?;
+            println!(
+                "Initialized hardware + YubiKey FactorSeal vault at {}",
+                path.display()
+            );
+        }
         return Ok(());
     }
-    Vault::create(path)?;
-    println!(
-        "Initialized transitional hardware-only FactorSeal vault at {} (not design-compliant 2FA)",
-        path.display()
-    );
+    if biometric {
+        Vault::create_with_biometric(path)?;
+        println!(
+            "Initialized biometric-gated hardware FactorSeal vault at {} (no independent second key share)",
+            path.display()
+        );
+    } else {
+        Vault::create(path)?;
+        println!(
+            "Initialized transitional hardware-only FactorSeal vault at {} (not design-compliant 2FA)",
+            path.display()
+        );
+    }
     Ok(())
 }
 
@@ -525,6 +561,7 @@ struct Status {
     version: u32,
     vault_id: String,
     unlock_method: String,
+    factors: Vec<FactorKind>,
     hardware_backend: Option<String>,
     yubikey_serial: Option<u32>,
     state: &'static str,
@@ -533,6 +570,18 @@ struct Status {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn init_accepts_biometric_factor_selection() {
+        let cli = Cli::try_parse_from(["factorseal", "init", "--biometric"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Init {
+                biometric: true,
+                ..
+            }
+        ));
+    }
 
     #[test]
     fn limited_reads_accept_the_boundary_and_reject_more() {

--- a/src/factor.rs
+++ b/src/factor.rs
@@ -1,0 +1,73 @@
+use serde::Serialize;
+
+/// A factor that can participate in a vault unlock policy.
+///
+/// Only factors returned by [`crate::Vault::info`] are configured for that
+/// vault. Some variants describe provider families whose concrete provider is
+/// still being developed.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "kebab-case")]
+pub enum FactorKind {
+    /// A legacy password wrapping the complete vault key.
+    Password,
+    /// Platform hardware such as a TPM or Secure Enclave.
+    PlatformHardware,
+    /// Platform biometric user verification gating a hardware operation.
+    Biometric,
+    /// A challenge-response authenticator app.
+    ///
+    /// A conventional TOTP code alone cannot protect an offline vault-key
+    /// share because the local verifier would also need to retain the TOTP
+    /// seed.
+    AuthenticatorApp,
+    /// A YubiKey using the PIV provider.
+    #[serde(rename = "yubikey")]
+    YubiKey,
+    /// A passkey capable of returning stable PRF or `hmac-secret` output.
+    Passkey,
+}
+
+impl FactorKind {
+    /// Return the stable name used by CLI metadata.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Password => "password",
+            Self::PlatformHardware => "platform-hardware",
+            Self::Biometric => "biometric",
+            Self::AuthenticatorApp => "authenticator-app",
+            Self::YubiKey => "yubikey",
+            Self::Passkey => "passkey",
+        }
+    }
+}
+
+impl std::fmt::Display for FactorKind {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn factor_names_are_stable() {
+        for (factor, expected) in [
+            (FactorKind::Password, "password"),
+            (FactorKind::PlatformHardware, "platform-hardware"),
+            (FactorKind::Biometric, "biometric"),
+            (FactorKind::AuthenticatorApp, "authenticator-app"),
+            (FactorKind::YubiKey, "yubikey"),
+            (FactorKind::Passkey, "passkey"),
+        ] {
+            assert_eq!(factor.as_str(), expected);
+            assert_eq!(
+                serde_json::to_string(&factor).unwrap(),
+                format!("\"{expected}\"")
+            );
+        }
+    }
+}

--- a/src/hardware.rs
+++ b/src/hardware.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 use hardware_enclave::{
     AccessPolicy, BackendKind, EnclaveConfig, EncryptorHandle, create_encryptor,
 };
+#[cfg(target_os = "windows")]
+use hardware_enclave::{PlatformConfig, WindowsConfig};
 use zeroize::Zeroizing;
 
 use crate::{Error, Result};
@@ -51,11 +53,22 @@ pub(crate) struct PlatformProtector {
 }
 
 impl PlatformProtector {
-    pub(crate) fn open(root: &Path, label: &str) -> Result<Self> {
+    pub(crate) fn open(root: &Path, label: &str, biometric: bool) -> Result<Self> {
         let keys_dir = root.join(KEYS_DIRECTORY);
         let mut config = EnclaveConfig::new(APP_NAME, label);
         config.keys_dir = Some(keys_dir.clone());
-        config.access_policy = Some(AccessPolicy::None);
+        config.access_policy = Some(if biometric {
+            AccessPolicy::BiometricOnly
+        } else {
+            AccessPolicy::None
+        });
+        #[cfg(target_os = "windows")]
+        if biometric {
+            config.platform = PlatformConfig::Windows(WindowsConfig {
+                prefer_windows_hello_ux: true,
+                ..WindowsConfig::default()
+            });
+        }
 
         let handle = create_encryptor(&config).map_err(map_hardware_error)?;
         let backend = verify_hardware_backend(&handle, &keys_dir, label)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
 //!
 //! Two-factor authentication (2FA) is required by design for supported
 //! persistent vaults. The current 2FA provider combines platform hardware with
-//! a PIN-protected YubiKey.
+//! a PIN-protected YubiKey. Supported platform hardware can additionally
+//! require biometric user verification.
 //!
 //! A vault is unlocked once into an [`UnlockedVault`]. The session retains a
 //! zeroizing vault key, never a cache of decrypted credentials. Each `get`
@@ -10,9 +11,11 @@
 
 mod crypto;
 mod error;
+mod factor;
 mod vault;
 
 pub use error::{Error, Result};
+pub use factor::FactorKind;
 pub use vault::{
     CredentialMetadata, CredentialOptions, ReferenceOptions, SecretReference, UnlockedVault, Vault,
     VaultInfo,

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -17,7 +17,7 @@ use zeroize::Zeroizing;
 use crate::crypto::{self, KEY_BYTES, NONCE_BYTES};
 #[cfg(feature = "hardware")]
 use crate::hardware::{HardwareBackend, KeyProtector, PlatformProtector};
-use crate::{Error, Result};
+use crate::{Error, FactorKind, Result};
 
 const CONFIG_FILE: &str = "vault.json";
 const ENTRIES_DIRECTORY: &str = "entries";
@@ -68,6 +68,8 @@ pub struct VaultInfo {
     pub version: u32,
     pub vault_id: String,
     pub unlock_method: String,
+    /// Factors configured under an `all` policy, in evaluation order.
+    pub factors: Vec<FactorKind>,
     pub hardware_backend: Option<String>,
     pub yubikey_serial: Option<u32>,
 }
@@ -167,6 +169,37 @@ struct VaultConfig {
     unlock: UnlockConfig,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum PlatformAccessPolicy {
+    #[default]
+    None,
+    Biometric,
+}
+
+impl PlatformAccessPolicy {
+    #[allow(clippy::trivially_copy_pass_by_ref)] // serde's skip predicate takes `&T`.
+    const fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+
+    const fn requires_biometric(self) -> bool {
+        matches!(self, Self::Biometric)
+    }
+}
+
+fn hardware_factors(access_policy: PlatformAccessPolicy, yubikey: bool) -> Vec<FactorKind> {
+    let mut factors = Vec::with_capacity(2 + usize::from(yubikey));
+    factors.push(FactorKind::PlatformHardware);
+    if access_policy.requires_biometric() {
+        factors.push(FactorKind::Biometric);
+    }
+    if yubikey {
+        factors.push(FactorKind::YubiKey);
+    }
+    factors
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "method")]
 enum UnlockConfig {
@@ -182,12 +215,16 @@ enum UnlockConfig {
         backend: String,
         key_label: String,
         wrapped_key: String,
+        #[serde(default, skip_serializing_if = "PlatformAccessPolicy::is_none")]
+        access_policy: PlatformAccessPolicy,
     },
     #[serde(rename = "hardware+yubikey")]
     HardwareYubiKey {
         backend: String,
         key_label: String,
         wrapped_share: String,
+        #[serde(default, skip_serializing_if = "PlatformAccessPolicy::is_none")]
+        access_policy: PlatformAccessPolicy,
         yubikey: YubiKeyUnlock,
     },
 }
@@ -288,6 +325,7 @@ impl VaultConfig {
         backend: HardwareBackend,
         key_label: String,
         wrapped_key: &[u8],
+        access_policy: PlatformAccessPolicy,
     ) -> Self {
         Self {
             format: VAULT_FORMAT.to_owned(),
@@ -297,6 +335,7 @@ impl VaultConfig {
                 backend: backend.as_str().to_owned(),
                 key_label,
                 wrapped_key: encode(wrapped_key),
+                access_policy,
             },
         }
     }
@@ -307,6 +346,7 @@ impl VaultConfig {
         backend: HardwareBackend,
         key_label: String,
         wrapped_share: &[u8],
+        access_policy: PlatformAccessPolicy,
         enrolled: &crate::yubikey_factor::EnrolledYubiKey,
     ) -> Self {
         Self {
@@ -317,6 +357,7 @@ impl VaultConfig {
                 backend: backend.as_str().to_owned(),
                 key_label,
                 wrapped_share: encode(wrapped_share),
+                access_policy,
                 yubikey: YubiKeyUnlock {
                     serial: enrolled.serial,
                     slot: enrolled.slot.to_owned(),
@@ -338,7 +379,24 @@ impl Vault {
     pub fn create(path: impl AsRef<Path>) -> Result<UnlockedVault> {
         #[cfg(feature = "hardware")]
         {
-            create_hardware_vault(path.as_ref())
+            create_hardware_vault(path.as_ref(), PlatformAccessPolicy::None)
+        }
+        #[cfg(not(feature = "hardware"))]
+        {
+            let _ = path;
+            Err(Error::HardwareFeatureDisabled)
+        }
+    }
+
+    /// Create a transitional hardware vault gated by platform biometrics.
+    ///
+    /// Biometric verification gates the platform hardware operation but does
+    /// not protect an independent vault-key share. Combine it with a
+    /// share-protecting factor such as a YubiKey for FactorSeal's 2FA policy.
+    pub fn create_with_biometric(path: impl AsRef<Path>) -> Result<UnlockedVault> {
+        #[cfg(feature = "hardware")]
+        {
+            create_hardware_vault(path.as_ref(), PlatformAccessPolicy::Biometric)
         }
         #[cfg(not(feature = "hardware"))]
         {
@@ -370,7 +428,34 @@ impl Vault {
     ) -> Result<UnlockedVault> {
         #[cfg(all(feature = "hardware", feature = "yubikey"))]
         {
-            create_hardware_yubikey_vault(path.as_ref(), yubikey_pin)
+            create_hardware_yubikey_vault(path.as_ref(), yubikey_pin, PlatformAccessPolicy::None)
+        }
+        #[cfg(not(all(feature = "hardware", feature = "yubikey")))]
+        {
+            let _ = (path, yubikey_pin);
+            if cfg!(not(feature = "hardware")) {
+                Err(Error::HardwareFeatureDisabled)
+            } else {
+                Err(Error::YubiKeyFeatureDisabled)
+            }
+        }
+    }
+
+    /// Create a 2FA vault requiring platform biometrics and a YubiKey.
+    ///
+    /// The YubiKey and platform hardware protect independent vault-key shares;
+    /// biometric verification additionally gates access to the platform share.
+    pub fn create_with_biometric_and_yubikey(
+        path: impl AsRef<Path>,
+        yubikey_pin: &[u8],
+    ) -> Result<UnlockedVault> {
+        #[cfg(all(feature = "hardware", feature = "yubikey"))]
+        {
+            create_hardware_yubikey_vault(
+                path.as_ref(),
+                yubikey_pin,
+                PlatformAccessPolicy::Biometric,
+            )
         }
         #[cfg(not(all(feature = "hardware", feature = "yubikey")))]
         {
@@ -431,8 +516,9 @@ impl Vault {
             let path = path.as_ref();
             let session = unlock_hardware_vault(path, Some(yubikey_pin))?;
             let config = read_config(path)?;
-            let (backend, key_label) = hardware_fields(&config.unlock)?;
-            let protector = PlatformProtector::open(path, key_label)?;
+            let (backend, key_label, access_policy) = hardware_fields(&config.unlock)?;
+            let protector =
+                PlatformProtector::open(path, key_label, access_policy.requires_biometric())?;
             verify_recorded_backend(&protector, backend)?;
             let wrapped_key = session.with_key(|key| protector.wrap(key))?;
             let updated = VaultConfig::hardware(
@@ -440,6 +526,7 @@ impl Vault {
                 protector.backend(),
                 key_label.to_owned(),
                 &wrapped_key,
+                access_policy,
             );
             write_config(path, &updated)
         }
@@ -459,13 +546,34 @@ impl Vault {
         let path = path.as_ref();
         validate_vault_directory(path)?;
         let config = read_config(path)?;
-        let (unlock_method, hardware_backend, yubikey_serial) = match &config.unlock {
-            UnlockConfig::Password { .. } => ("password", None, None),
-            UnlockConfig::Hardware { backend, .. } => ("hardware", Some(backend.clone()), None),
-            UnlockConfig::HardwareYubiKey {
-                backend, yubikey, ..
+        let (unlock_method, factors, hardware_backend, yubikey_serial) = match &config.unlock {
+            UnlockConfig::Password { .. } => ("password", vec![FactorKind::Password], None, None),
+            UnlockConfig::Hardware {
+                backend,
+                access_policy,
+                ..
             } => (
-                "hardware+yubikey",
+                if access_policy.requires_biometric() {
+                    "hardware+biometric"
+                } else {
+                    "hardware"
+                },
+                hardware_factors(*access_policy, false),
+                Some(backend.clone()),
+                None,
+            ),
+            UnlockConfig::HardwareYubiKey {
+                backend,
+                access_policy,
+                yubikey,
+                ..
+            } => (
+                if access_policy.requires_biometric() {
+                    "hardware+biometric+yubikey"
+                } else {
+                    "hardware+yubikey"
+                },
+                hardware_factors(*access_policy, true),
                 Some(backend.clone()),
                 Some(yubikey.serial),
             ),
@@ -475,6 +583,7 @@ impl Vault {
             version: config.version,
             vault_id: config.vault_id,
             unlock_method: unlock_method.to_owned(),
+            factors,
             hardware_backend,
             yubikey_serial,
         })
@@ -529,8 +638,9 @@ impl Vault {
         {
             let path = path.as_ref();
             let session = Self::unlock_with_password(path, password)?;
-            let config =
-                session.with_key(|key| make_hardware_config(path, &session.vault_id, key))?;
+            let config = session.with_key(|key| {
+                make_hardware_config(path, &session.vault_id, key, PlatformAccessPolicy::None)
+            })?;
             write_config(path, &config)
         }
         #[cfg(not(feature = "hardware"))]
@@ -553,6 +663,7 @@ impl Vault {
             protector.backend(),
             key_label(&vault_id),
             &wrapped_key,
+            PlatformAccessPolicy::None,
         );
         write_initial_config(path, &config)?;
         Ok(UnlockedVault::new(path, vault_id, vault_key))
@@ -1199,18 +1310,25 @@ impl std::fmt::Debug for UnlockedVault {
 }
 
 #[cfg(feature = "hardware")]
-fn create_hardware_vault(path: &Path) -> Result<UnlockedVault> {
+fn create_hardware_vault(
+    path: &Path,
+    access_policy: PlatformAccessPolicy,
+) -> Result<UnlockedVault> {
     let (vault_id, vault_key) = prepare_new_vault(path)?;
-    let config = make_hardware_config(path, &vault_id, &vault_key)?;
+    let config = make_hardware_config(path, &vault_id, &vault_key, access_policy)?;
     write_initial_config(path, &config)?;
     Ok(UnlockedVault::new(path, vault_id, vault_key))
 }
 
 #[cfg(all(feature = "hardware", feature = "yubikey"))]
-fn create_hardware_yubikey_vault(path: &Path, pin: &[u8]) -> Result<UnlockedVault> {
+fn create_hardware_yubikey_vault(
+    path: &Path,
+    pin: &[u8],
+    access_policy: PlatformAccessPolicy,
+) -> Result<UnlockedVault> {
     let (vault_id, vault_key) = prepare_new_vault(path)?;
     let label = key_label(&vault_id);
-    let protector = PlatformProtector::open(path, &label)?;
+    let protector = PlatformProtector::open(path, &label, access_policy.requires_biometric())?;
 
     let mut yubikey_share = Zeroizing::new([0_u8; KEY_BYTES]);
     getrandom::fill(&mut *yubikey_share)?;
@@ -1223,6 +1341,7 @@ fn create_hardware_yubikey_vault(path: &Path, pin: &[u8]) -> Result<UnlockedVaul
         protector.backend(),
         label,
         &wrapped_platform_share,
+        access_policy,
         &enrolled,
     );
     write_initial_config(path, &config)?;
@@ -1234,15 +1353,17 @@ fn make_hardware_config(
     path: &Path,
     vault_id: &[u8; VAULT_ID_BYTES],
     vault_key: &[u8; KEY_BYTES],
+    access_policy: PlatformAccessPolicy,
 ) -> Result<VaultConfig> {
     let label = key_label(vault_id);
-    let protector = PlatformProtector::open(path, &label)?;
+    let protector = PlatformProtector::open(path, &label, access_policy.requires_biometric())?;
     let wrapped_key = protector.wrap(vault_key)?;
     Ok(VaultConfig::hardware(
         encode(vault_id),
         protector.backend(),
         label,
         &wrapped_key,
+        access_policy,
     ))
 }
 
@@ -1259,8 +1380,10 @@ fn unlock_hardware_vault(path: &Path, yubikey_pin: Option<&[u8]>) -> Result<Unlo
             backend,
             key_label,
             wrapped_key,
+            access_policy,
         } => {
-            let protector = PlatformProtector::open(path, key_label)?;
+            let protector =
+                PlatformProtector::open(path, key_label, access_policy.requires_biometric())?;
             verify_recorded_backend(&protector, backend)?;
             let wrapped_key = decode(wrapped_key, "wrapped_key").map_err(Error::InvalidMetadata)?;
             decode_key(&protector.unwrap(&wrapped_key)?, "hardware vault key")?
@@ -1269,10 +1392,12 @@ fn unlock_hardware_vault(path: &Path, yubikey_pin: Option<&[u8]>) -> Result<Unlo
             backend,
             key_label,
             wrapped_share,
+            access_policy,
             yubikey,
         } => {
             let pin = yubikey_pin.ok_or(Error::YubiKeyRequired)?;
-            let protector = PlatformProtector::open(path, key_label)?;
+            let protector =
+                PlatformProtector::open(path, key_label, access_policy.requires_biometric())?;
             verify_recorded_backend(&protector, backend)?;
             let wrapped_share =
                 decode(wrapped_share, "wrapped_share").map_err(Error::InvalidMetadata)?;
@@ -1330,12 +1455,13 @@ fn verify_recorded_backend(protector: &impl KeyProtector, recorded_backend: &str
 #[cfg(all(feature = "hardware", feature = "yubikey"))]
 fn add_yubikey_factor(path: &Path, session: &UnlockedVault, pin: &[u8]) -> Result<()> {
     let config = read_config(path)?;
-    let (backend, key_label, wrapped_key) = match &config.unlock {
+    let (backend, key_label, wrapped_key, access_policy) = match &config.unlock {
         UnlockConfig::Hardware {
             backend,
             key_label,
             wrapped_key,
-        } => (backend, key_label, wrapped_key),
+            access_policy,
+        } => (backend, key_label, wrapped_key, *access_policy),
         UnlockConfig::HardwareYubiKey { .. } => {
             return Err(Error::InvalidMetadata(
                 "vault already requires a YubiKey".to_owned(),
@@ -1344,7 +1470,7 @@ fn add_yubikey_factor(path: &Path, session: &UnlockedVault, pin: &[u8]) -> Resul
         UnlockConfig::Password { .. } => return Err(Error::PasswordFeatureDisabled),
     };
 
-    let protector = PlatformProtector::open(path, key_label)?;
+    let protector = PlatformProtector::open(path, key_label, access_policy.requires_biometric())?;
     verify_recorded_backend(&protector, backend)?;
     // Confirm that the current hardware wrapping still opens the same key
     // before replacing the policy metadata.
@@ -1367,17 +1493,21 @@ fn add_yubikey_factor(path: &Path, session: &UnlockedVault, pin: &[u8]) -> Resul
         protector.backend(),
         key_label.clone(),
         &wrapped_platform_share,
+        access_policy,
         &enrolled,
     );
     write_config(path, &updated)
 }
 
 #[cfg(all(feature = "hardware", feature = "yubikey"))]
-fn hardware_fields(unlock: &UnlockConfig) -> Result<(&str, &str)> {
+fn hardware_fields(unlock: &UnlockConfig) -> Result<(&str, &str, PlatformAccessPolicy)> {
     match unlock {
         UnlockConfig::HardwareYubiKey {
-            backend, key_label, ..
-        } => Ok((backend, key_label)),
+            backend,
+            key_label,
+            access_policy,
+            ..
+        } => Ok((backend, key_label, *access_policy)),
         UnlockConfig::Hardware { .. } => Err(Error::InvalidMetadata(
             "vault does not require a YubiKey".to_owned(),
         )),
@@ -2406,7 +2536,50 @@ mod tests {
         assert_eq!(info.version, 2);
         assert_eq!(info.vault_id, expected_id);
         assert_eq!(info.unlock_method, "hardware");
+        assert_eq!(info.factors, vec![FactorKind::PlatformHardware]);
         assert_eq!(info.hardware_backend.as_deref(), Some("tpm"));
+    }
+
+    #[test]
+    fn factor_inventory_includes_verification_and_key_share_factors() {
+        assert_eq!(
+            hardware_factors(PlatformAccessPolicy::Biometric, true),
+            vec![
+                FactorKind::PlatformHardware,
+                FactorKind::Biometric,
+                FactorKind::YubiKey
+            ]
+        );
+    }
+
+    #[test]
+    fn biometric_policy_is_reported_as_a_factor() {
+        let (_directory, path, vault) = vault();
+        drop(vault);
+
+        let mut config = read_config(&path).unwrap();
+        let UnlockConfig::Hardware { access_policy, .. } = &mut config.unlock else {
+            panic!("expected hardware config");
+        };
+        *access_policy = PlatformAccessPolicy::Biometric;
+        let config_path = path.join(CONFIG_FILE);
+        atomic_write(&config_path, &serialize(&config, &config_path).unwrap()).unwrap();
+
+        let info = Vault::info(path).unwrap();
+        assert_eq!(info.unlock_method, "hardware+biometric");
+        assert_eq!(
+            info.factors,
+            vec![FactorKind::PlatformHardware, FactorKind::Biometric]
+        );
+    }
+
+    #[test]
+    fn default_hardware_policy_keeps_the_existing_wire_format() {
+        let (_directory, path, vault) = vault();
+        drop(vault);
+
+        let stored = fs::read_to_string(path.join(CONFIG_FILE)).unwrap();
+        assert!(!stored.contains("access_policy"));
     }
 
     #[cfg(feature = "password")]
@@ -2415,6 +2588,10 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("vault");
         let vault = Vault::create_with_password(&path, b"old password").unwrap();
+        assert_eq!(
+            Vault::info(&path).unwrap().factors,
+            vec![FactorKind::Password]
+        );
         vault.set("service", "account", b"survives").unwrap();
         drop(vault);
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -71,6 +71,7 @@ fn keyring_cli_round_trip_and_password_change() {
     let status: serde_json::Value = serde_json::from_slice(&status.stdout).unwrap();
     assert_eq!(status["state"], "locked");
     assert_eq!(status["unlock_method"], "password");
+    assert_eq!(status["factors"], serde_json::json!(["password"]));
 
     let changed = command(&vault, &password)
         .args([


### PR DESCRIPTION
## Summary

- Add a public, provider-neutral factor inventory and expose configured factors through `VaultInfo` and CLI status output.
- Add biometric-gated platform hardware vault creation and unlock, including composition with the existing YubiKey share.
- Preserve the existing vault wire format when no biometric policy is selected.
- Document which factors are implemented today and the cryptographic requirements for future passkey and authenticator-app providers.

## Why

FactorSeal previously hard-coded platform hardware plus YubiKey terminology and had no way to require platform biometric verification. This change makes configured factors explicit while preserving the independent-share security policy: biometrics gate the platform operation but are not counted as another independently protected share.

Passkeys and authenticator apps are represented as provider families but are not claimed as implemented. The documentation explains that a passkey provider needs stable PRF/`hmac-secret` output and that conventional TOTP cannot independently protect an offline vault share.

## User and developer impact

- `factorseal init --biometric` creates a biometric-gated transitional hardware vault on supported platforms.
- `factorseal init --biometric --yubikey` adds biometric verification to the compliant hardware-plus-YubiKey construction.
- `factorseal status` reports a stable `factors` list.
- Existing vaults continue to deserialize with the default interaction-free platform policy.
- Unsupported biometric platforms fail instead of silently dropping the configured policy.

## Validation

- `cargo test`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --no-default-features`
- `cargo check --no-default-features --features cli,password`
- `RUSTDOCFLAGS='-D warnings' cargo doc --all-features --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check`
