### PR TITLE
Prepare Factorseal for external Aliro support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to FactorSeal will be documented in this file.
 
 ## Unreleased
 
+- Add a protocol-neutral phone-factor boundary with short-lived vault-bound
+  requests, enrolled-credential response validation, distinct transport and
+  authorization errors, and zeroizing phone-share handling. Aliro remains an
+  external protocol implementation.
 - Establish two-factor authentication as a design requirement for every
   supported persistent vault; hardware-only and legacy-password paths are
   prototype compatibility gaps, not deployment profiles.

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ another factor's key operation; those are different security properties.
 | Biometric | Gates the platform hardware operation | Implemented with `--biometric` where `hardware-enclave` can enforce `BiometricOnly` |
 | YubiKey | Protects an independent share through PIV | Implemented behind `yubikey` |
 | Passkey | Must protect a share with stable WebAuthn PRF/CTAP `hmac-secret` output | Provider planned |
-| Authenticator app | Must release a share through cryptographic challenge-response | Provider planned; ordinary TOTP is not sufficient |
+| Phone | Holds an independently protected share and releases it through an authenticated, user-authorized session | Protocol-neutral boundary implemented; transport and vault enrollment planned |
 
 Biometric verification does not create another independently protected share,
 so `hardware + biometric` remains a transitional profile. Combining
@@ -151,13 +151,15 @@ platforms fail instead of silently dropping the policy.
 
 A conventional six-digit TOTP app cannot independently protect an offline
 vault share: a local verifier would have to retain the TOTP seed, and a copied
-verifier could then calculate the same codes. A future phone provider must
-hold its own key material and answer a vault-bound challenge. Likewise, a
-passkey provider must use stable PRF or `hmac-secret` output; an ordinary
-authentication signature is not treated as a wrapping key.
+verifier could then calculate the same codes. A phone provider must hold its
+own key material and answer a vault-bound challenge. FactorSeal now exposes a
+protocol-neutral, one-shot phone-factor request/response boundary; Aliro,
+Bluetooth, Android, enrollment, and vault wrapping remain separate work.
+Likewise, a passkey provider must use stable PRF or `hmac-secret` output; an
+ordinary authentication signature is not treated as a wrapping key.
 
 The current prototype supports one YubiKey. Backup authenticators, passkeys,
-phone challenge-response providers, atomic authenticator replacement, and
+phone enrollment and transport adapters, atomic authenticator replacement, and
 recovery remain target features.
 
 Hardware-only version 2 APIs remain temporarily available for prototype
@@ -226,9 +228,11 @@ The current version 2 prototype implements:
   `session` collections;
 - approval grants scoped to one caller and one item.
 
-It does not yet implement independent backup authenticators, passkey or phone
-challenge-response providers, recovery, atomic factor replacement, audit
-events, or rollback protection.
+It does not yet implement independent backup authenticators, passkey providers,
+or a phone-backed vault provider. The phone-factor boundary validates
+short-lived, vault-bound responses and zeroizes returned shares; enrollment,
+transport, vault wrapping, recovery, atomic factor replacement, audit events,
+and rollback protection remain future work.
 
 The prototype also retains hardware-only and legacy-password compatibility
 paths. Those paths are implementation gaps relative to the required 2FA design,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,10 +52,11 @@ must not be treated as supported deployment profiles.
 - The YubiKey provider supports one pre-provisioned RSA-2048 PIV key in slot
   `9d` on firmware 5.2.3+. It does not provision keys, support backup
   YubiKeys, or provide recovery.
-- Passkey and authenticator-app providers are not implemented. A passkey
-  provider must use stable PRF/`hmac-secret` output, and a phone provider must
-  hold independent key material. TOTP-only verification is not accepted as an
-  offline share-protection mechanism.
+- Passkey and phone vault providers are not implemented. A passkey provider
+  must use stable PRF/`hmac-secret` output, and a phone provider must retain
+  independent key material rather than return an authorization boolean. The
+  protocol-neutral phone request/response boundary is implemented, but there
+  is no enrollment, transport adapter, or vault-key wrapping stanza yet.
 - Losing or resetting the platform hardware or required YubiKey permanently
   loses access unless secrets were separately backed up. A recovery-key export
   is not implemented.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,10 +67,30 @@ share and remains a transitional profile.
 
 Future passkey providers must derive a wrapping key from stable WebAuthn PRF
 or CTAP `hmac-secret` output. Authentication signatures are not assumed to be
-stable key material. Future authenticator-app providers must hold independent
-key material and use vault-bound challenge-response. TOTP verification alone
-cannot protect an offline share because the local verifier would need the
-same TOTP seed.
+stable key material. Phone providers must hold independent key material and
+use vault-bound challenge-response. TOTP verification alone cannot protect an
+offline share because the local verifier would need the same TOTP seed.
+
+## Phone-factor boundary
+
+FactorSeal owns vault policy and the FactorSeal phone-share exchange, but it
+does not own the protocol used to authenticate a phone. The `PhoneFactor`
+boundary allows an external adapter to run that protocol and return a response
+from the active, mutually authenticated, user-authorized session.
+
+Each `PhoneUnlockRequest` contains the protocol version, vault ID, fresh
+request ID, fresh challenge, requested action, expiration time, and laptop
+name. FactorSeal accepts a response only when it echoes the version, vault,
+request, challenge, and action; arrives before expiration; and names an
+enrolled credential. Validation consumes the request so it cannot be reused.
+The returned `PhoneShare` is held in zeroizing memory and is never represented
+as an unlock boolean.
+
+Aliro belongs in a separate crate or repository that implements the adapter.
+Its APDU/TLV codecs, cryptography, state machines, conformance fixtures, BLE
+transport, and platform bindings remain outside this crate. This separation
+also allows FactorSeal to test vault behavior with a mock provider before an
+Aliro transport is available.
 
 The version 2 format and public API still contain hardware-only paths, with or
 without a biometric gate, for prototype development and migration. Those

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -90,11 +90,24 @@ An ordinary passkey authentication signature is not sufficient. Signatures
 are authentication evidence, may be randomized, and are not a stable secret
 from which the same wrapping key can safely be reconstructed.
 
-## Authenticator apps
+## Phone companions
 
-A phone authenticator is also a target provider. To meet the provider
-contract, the phone must retain independent key material and release or help
-derive a share only after answering a vault-bound challenge.
+A phone companion is a target vault provider. It must retain independent key
+material and release a share only through a vault-bound, user-authorized,
+mutually authenticated session. FactorSeal exposes protocol-neutral
+`PhoneFactor`, `PhoneUnlockRequest`, and `PhoneUnlockResponse` types for this
+integration.
+
+Requests are one-shot and expire after at most 60 seconds. Before exposing the
+share, FactorSeal validates the protocol version, vault ID, request ID,
+challenge, action, expiration, and enrolled credential ID. The adapter remains
+responsible for transport security, phone and laptop mutual authentication,
+user authorization, and ensuring the response came from the same live session.
+Aliro support should implement this adapter in an independent crate rather
+than adding Aliro codecs or state machines to FactorSeal.
+
+This boundary does not yet enroll phones, add phone wrapping stanzas to the
+vault format, or connect a returned share to vault unlock.
 
 Conventional TOTP is deliberately not treated as a share-protecting factor in
 an offline vault. The local verifier would need the TOTP seed in order to

--- a/src/factor.rs
+++ b/src/factor.rs
@@ -15,12 +15,11 @@ pub enum FactorKind {
     PlatformHardware,
     /// Platform biometric user verification gating a hardware operation.
     Biometric,
-    /// A challenge-response authenticator app.
+    /// A phone holding an independently protected vault-key share.
     ///
-    /// A conventional TOTP code alone cannot protect an offline vault-key
-    /// share because the local verifier would also need to retain the TOTP
-    /// seed.
-    AuthenticatorApp,
+    /// The transport and mutual-authentication protocol, such as Aliro, are
+    /// separate from FactorSeal's vault policy and share handling.
+    Phone,
     /// A YubiKey using the PIV provider.
     #[serde(rename = "yubikey")]
     YubiKey,
@@ -36,7 +35,7 @@ impl FactorKind {
             Self::Password => "password",
             Self::PlatformHardware => "platform-hardware",
             Self::Biometric => "biometric",
-            Self::AuthenticatorApp => "authenticator-app",
+            Self::Phone => "phone",
             Self::YubiKey => "yubikey",
             Self::Passkey => "passkey",
         }
@@ -59,7 +58,7 @@ mod tests {
             (FactorKind::Password, "password"),
             (FactorKind::PlatformHardware, "platform-hardware"),
             (FactorKind::Biometric, "biometric"),
-            (FactorKind::AuthenticatorApp, "authenticator-app"),
+            (FactorKind::Phone, "phone"),
             (FactorKind::YubiKey, "yubikey"),
             (FactorKind::Passkey, "passkey"),
         ] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,17 @@
 mod crypto;
 mod error;
 mod factor;
+mod phone_factor;
 mod vault;
 
 pub use error::{Error, Result};
 pub use factor::FactorKind;
+pub use phone_factor::{
+    MAX_PHONE_UNLOCK_LIFETIME, PHONE_CHALLENGE_BYTES, PHONE_CREDENTIAL_ID_BYTES,
+    PHONE_REQUEST_ID_BYTES, PHONE_SHARE_BYTES, PHONE_UNLOCK_VERSION, PHONE_VAULT_ID_BYTES,
+    PhoneCredentialId, PhoneFactor, PhoneFactorError, PhoneFactorFuture, PhoneFactorResult,
+    PhoneShare, PhoneUnlockAction, PhoneUnlockRequest, PhoneUnlockResponse, ValidatedPhoneShare,
+};
 pub use vault::{
     CredentialMetadata, CredentialOptions, ReferenceOptions, SecretReference, UnlockedVault, Vault,
     VaultInfo,

--- a/src/phone_factor.rs
+++ b/src/phone_factor.rs
@@ -1,0 +1,516 @@
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+use zeroize::Zeroizing;
+
+/// Version of FactorSeal's protocol-neutral phone unlock exchange.
+pub const PHONE_UNLOCK_VERSION: u8 = 1;
+/// Number of bytes in a FactorSeal vault identifier.
+pub const PHONE_VAULT_ID_BYTES: usize = 16;
+/// Number of bytes in a phone credential identifier.
+pub const PHONE_CREDENTIAL_ID_BYTES: usize = 16;
+/// Number of bytes in a one-time phone unlock request identifier.
+pub const PHONE_REQUEST_ID_BYTES: usize = 16;
+/// Number of bytes in a one-time phone unlock challenge.
+pub const PHONE_CHALLENGE_BYTES: usize = 32;
+/// Number of bytes in the independent share retained by a phone.
+pub const PHONE_SHARE_BYTES: usize = 32;
+/// Longest phone unlock request accepted by the protocol-neutral boundary.
+pub const MAX_PHONE_UNLOCK_LIFETIME: Duration = Duration::from_secs(60);
+
+const MAX_LAPTOP_NAME_BYTES: usize = 255;
+
+/// Action authorized by a phone unlock request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum PhoneUnlockAction {
+    /// Release the enrolled phone share for a keyring unlock.
+    UnlockKeyring,
+}
+
+impl PhoneUnlockAction {
+    /// Return the stable wire name used by protocol adapters.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::UnlockKeyring => "unlock-keyring",
+        }
+    }
+}
+
+/// Public, vault-scoped identifier for one enrolled phone credential.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct PhoneCredentialId([u8; PHONE_CREDENTIAL_ID_BYTES]);
+
+impl PhoneCredentialId {
+    /// Construct an identifier from its canonical bytes.
+    #[must_use]
+    pub const fn new(bytes: [u8; PHONE_CREDENTIAL_ID_BYTES]) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the canonical identifier bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; PHONE_CREDENTIAL_ID_BYTES] {
+        &self.0
+    }
+}
+
+/// Secret phone-held material used to reconstruct or unwrap a vault key.
+///
+/// The bytes are zeroized when this value is dropped. This type deliberately
+/// does not implement `Clone`, `Serialize`, or a revealing `Debug` format.
+pub struct PhoneShare(Zeroizing<[u8; PHONE_SHARE_BYTES]>);
+
+impl PhoneShare {
+    /// Move plaintext phone-share bytes into zeroizing memory.
+    #[must_use]
+    pub fn new(bytes: [u8; PHONE_SHARE_BYTES]) -> Self {
+        Self(Zeroizing::new(bytes))
+    }
+
+    /// Expose the share to the vault-key derivation operation.
+    #[must_use]
+    pub fn expose_secret(&self) -> &[u8; PHONE_SHARE_BYTES] {
+        &self.0
+    }
+
+    /// Move the share into its zeroizing buffer.
+    #[must_use]
+    pub fn into_zeroizing(self) -> Zeroizing<[u8; PHONE_SHARE_BYTES]> {
+        self.0
+    }
+}
+
+impl fmt::Debug for PhoneShare {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("PhoneShare([REDACTED])")
+    }
+}
+
+/// One-shot request passed to an authenticated phone-factor transport.
+///
+/// The transport may serialize these fields using its own framing. An Aliro
+/// adapter, for example, can carry them in an encrypted third-party exchange
+/// without introducing Aliro types into FactorSeal.
+#[derive(Debug, Eq, PartialEq)]
+pub struct PhoneUnlockRequest {
+    version: u8,
+    vault_id: [u8; PHONE_VAULT_ID_BYTES],
+    request_id: [u8; PHONE_REQUEST_ID_BYTES],
+    challenge: [u8; PHONE_CHALLENGE_BYTES],
+    action: PhoneUnlockAction,
+    expires_at: u64,
+    laptop_name: String,
+}
+
+impl PhoneUnlockRequest {
+    /// Create a fresh request with random request and challenge values.
+    ///
+    /// `now` is the current Unix timestamp in seconds. Lifetimes are limited
+    /// to [`MAX_PHONE_UNLOCK_LIFETIME`] so a stale authenticated transport
+    /// cannot retain a useful request indefinitely.
+    pub fn new(
+        vault_id: [u8; PHONE_VAULT_ID_BYTES],
+        laptop_name: impl Into<String>,
+        now: u64,
+        lifetime: Duration,
+    ) -> PhoneFactorResult<Self> {
+        let laptop_name = laptop_name.into();
+        if laptop_name.is_empty()
+            || laptop_name.len() > MAX_LAPTOP_NAME_BYTES
+            || laptop_name.contains('\0')
+        {
+            return Err(PhoneFactorError::InvalidLaptopName);
+        }
+
+        let lifetime_seconds = lifetime.as_secs();
+        if lifetime_seconds == 0 || lifetime > MAX_PHONE_UNLOCK_LIFETIME {
+            return Err(PhoneFactorError::InvalidLifetime {
+                maximum_seconds: MAX_PHONE_UNLOCK_LIFETIME.as_secs(),
+            });
+        }
+        let expires_at = now
+            .checked_add(lifetime_seconds)
+            .ok_or(PhoneFactorError::ExpirationOverflow)?;
+
+        let mut request_id = [0_u8; PHONE_REQUEST_ID_BYTES];
+        getrandom::fill(&mut request_id)
+            .map_err(|error| PhoneFactorError::Random(error.to_string()))?;
+        let mut challenge = [0_u8; PHONE_CHALLENGE_BYTES];
+        getrandom::fill(&mut challenge)
+            .map_err(|error| PhoneFactorError::Random(error.to_string()))?;
+
+        Ok(Self {
+            version: PHONE_UNLOCK_VERSION,
+            vault_id,
+            request_id,
+            challenge,
+            action: PhoneUnlockAction::UnlockKeyring,
+            expires_at,
+            laptop_name,
+        })
+    }
+
+    /// Return the FactorSeal phone exchange version.
+    #[must_use]
+    pub const fn version(&self) -> u8 {
+        self.version
+    }
+
+    /// Return the vault identifier bound to this request.
+    #[must_use]
+    pub const fn vault_id(&self) -> &[u8; PHONE_VAULT_ID_BYTES] {
+        &self.vault_id
+    }
+
+    /// Return the fresh, one-time request identifier.
+    #[must_use]
+    pub const fn request_id(&self) -> &[u8; PHONE_REQUEST_ID_BYTES] {
+        &self.request_id
+    }
+
+    /// Return the fresh, one-time challenge.
+    #[must_use]
+    pub const fn challenge(&self) -> &[u8; PHONE_CHALLENGE_BYTES] {
+        &self.challenge
+    }
+
+    /// Return the requested action.
+    #[must_use]
+    pub const fn action(&self) -> PhoneUnlockAction {
+        self.action
+    }
+
+    /// Return the exclusive Unix expiration timestamp.
+    #[must_use]
+    pub const fn expires_at(&self) -> u64 {
+        self.expires_at
+    }
+
+    /// Return the laptop name displayed for user authorization.
+    #[must_use]
+    pub fn laptop_name(&self) -> &str {
+        &self.laptop_name
+    }
+
+    /// Verify and consume a response from an authenticated current session.
+    ///
+    /// Consuming the request makes the intended one-response lifecycle
+    /// explicit. The caller must still invalidate the transport session and
+    /// request ID after any success or failure.
+    pub fn accept_response(
+        self,
+        response: PhoneUnlockResponse,
+        now: u64,
+        enrolled_credentials: &[PhoneCredentialId],
+    ) -> PhoneFactorResult<ValidatedPhoneShare> {
+        if now >= self.expires_at {
+            return Err(PhoneFactorError::Expired);
+        }
+        if response.version != self.version {
+            return Err(PhoneFactorError::UnsupportedVersion {
+                expected: self.version,
+                actual: response.version,
+            });
+        }
+        if response.vault_id != self.vault_id {
+            return Err(PhoneFactorError::BindingMismatch { field: "vault ID" });
+        }
+        if response.request_id != self.request_id {
+            return Err(PhoneFactorError::BindingMismatch {
+                field: "request ID",
+            });
+        }
+        if response.challenge != self.challenge {
+            return Err(PhoneFactorError::BindingMismatch { field: "challenge" });
+        }
+        if response.action != self.action {
+            return Err(PhoneFactorError::BindingMismatch { field: "action" });
+        }
+        if !enrolled_credentials.contains(&response.credential_id) {
+            return Err(PhoneFactorError::CredentialNotEnrolled);
+        }
+
+        Ok(ValidatedPhoneShare {
+            credential_id: response.credential_id,
+            phone_share: response.phone_share,
+        })
+    }
+}
+
+/// Response produced only after authenticating the phone and authorizing use.
+///
+/// Implementations of [`PhoneFactor`] must not construct this response from an
+/// unauthenticated transport or from a different protocol session.
+#[derive(Debug)]
+pub struct PhoneUnlockResponse {
+    version: u8,
+    vault_id: [u8; PHONE_VAULT_ID_BYTES],
+    request_id: [u8; PHONE_REQUEST_ID_BYTES],
+    challenge: [u8; PHONE_CHALLENGE_BYTES],
+    action: PhoneUnlockAction,
+    credential_id: PhoneCredentialId,
+    phone_share: PhoneShare,
+}
+
+impl PhoneUnlockResponse {
+    /// Construct a response decoded from an authenticated phone session.
+    #[must_use]
+    pub fn new(
+        version: u8,
+        vault_id: [u8; PHONE_VAULT_ID_BYTES],
+        request_id: [u8; PHONE_REQUEST_ID_BYTES],
+        challenge: [u8; PHONE_CHALLENGE_BYTES],
+        action: PhoneUnlockAction,
+        credential_id: PhoneCredentialId,
+        phone_share: PhoneShare,
+    ) -> Self {
+        Self {
+            version,
+            vault_id,
+            request_id,
+            challenge,
+            action,
+            credential_id,
+            phone_share,
+        }
+    }
+}
+
+/// An enrolled phone share after complete request/response binding checks.
+#[derive(Debug)]
+pub struct ValidatedPhoneShare {
+    credential_id: PhoneCredentialId,
+    phone_share: PhoneShare,
+}
+
+impl ValidatedPhoneShare {
+    /// Return the enrolled credential that released this share.
+    #[must_use]
+    pub const fn credential_id(&self) -> PhoneCredentialId {
+        self.credential_id
+    }
+
+    /// Borrow the zeroizing phone share for vault-key derivation.
+    #[must_use]
+    pub fn phone_share(&self) -> &PhoneShare {
+        &self.phone_share
+    }
+
+    /// Split the validated response into its credential and share.
+    #[must_use]
+    pub fn into_parts(self) -> (PhoneCredentialId, PhoneShare) {
+        (self.credential_id, self.phone_share)
+    }
+}
+
+/// Error returned while constructing or executing a phone-factor request.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum PhoneFactorError {
+    /// No configured phone transport is currently available.
+    #[error("phone factor transport is unavailable: {0}")]
+    Unavailable(String),
+    /// The request made no progress before its transport deadline.
+    #[error("phone factor request timed out")]
+    TimedOut,
+    /// The caller or phone dismissed the request.
+    #[error("phone factor request was cancelled")]
+    Cancelled,
+    /// The phone rejected user authentication or authorization.
+    #[error("phone factor authorization was denied")]
+    AuthorizationDenied,
+    /// The authenticated transport failed its protocol exchange.
+    #[error("phone factor protocol failed: {0}")]
+    Protocol(String),
+    /// The request's user-visible laptop name is invalid.
+    #[error("phone unlock laptop name must be non-empty, contain no NUL, and fit in 255 bytes")]
+    InvalidLaptopName,
+    /// The request lifetime is zero or exceeds the configured maximum.
+    #[error("phone unlock lifetime must be between 1 and {maximum_seconds} seconds")]
+    InvalidLifetime { maximum_seconds: u64 },
+    /// The expiration timestamp cannot be represented.
+    #[error("phone unlock expiration timestamp overflowed")]
+    ExpirationOverflow,
+    /// Secure random request generation failed.
+    #[error("phone unlock random-number generation failed: {0}")]
+    Random(String),
+    /// The response arrived after the request expired.
+    #[error("phone unlock request expired")]
+    Expired,
+    /// The response used a different FactorSeal phone exchange version.
+    #[error("unsupported phone unlock version {actual}; expected {expected}")]
+    UnsupportedVersion { expected: u8, actual: u8 },
+    /// An echoed response field did not match the active request.
+    #[error("phone unlock response is not bound to the active {field}")]
+    BindingMismatch { field: &'static str },
+    /// The responding credential is not enrolled for this vault.
+    #[error("phone credential is not enrolled for this vault")]
+    CredentialNotEnrolled,
+}
+
+/// Result produced by a phone-factor adapter.
+pub type PhoneFactorResult<T> = std::result::Result<T, PhoneFactorError>;
+
+/// Future returned by a dynamically selected phone-factor adapter.
+pub type PhoneFactorFuture<'a> =
+    Pin<Box<dyn Future<Output = PhoneFactorResult<PhoneUnlockResponse>> + Send + 'a>>;
+
+/// Protocol-neutral provider for one authenticated phone-factor exchange.
+///
+/// Implementations are responsible for mutual authentication, encryption,
+/// user verification, timeouts, cancellation, and ensuring the response came
+/// from the same current session that received `request`. FactorSeal performs
+/// the remaining vault/request/action/credential binding checks with
+/// [`PhoneUnlockRequest::accept_response`].
+pub trait PhoneFactor: Send {
+    /// Ask an authenticated phone to release its enrolled share.
+    fn request_share<'a>(&'a mut self, request: &'a PhoneUnlockRequest) -> PhoneFactorFuture<'a>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VAULT_ID: [u8; PHONE_VAULT_ID_BYTES] = [0x11; PHONE_VAULT_ID_BYTES];
+    const CREDENTIAL_ID: PhoneCredentialId =
+        PhoneCredentialId::new([0x22; PHONE_CREDENTIAL_ID_BYTES]);
+
+    fn new_request() -> PhoneUnlockRequest {
+        PhoneUnlockRequest::new(VAULT_ID, "domen-laptop", 1_000, Duration::from_secs(10)).unwrap()
+    }
+
+    fn response_for(request: &PhoneUnlockRequest) -> PhoneUnlockResponse {
+        PhoneUnlockResponse::new(
+            request.version(),
+            *request.vault_id(),
+            *request.request_id(),
+            *request.challenge(),
+            request.action(),
+            CREDENTIAL_ID,
+            PhoneShare::new([0x33; PHONE_SHARE_BYTES]),
+        )
+    }
+
+    #[test]
+    fn request_fields_are_versioned_and_short_lived() {
+        let request = new_request();
+
+        assert_eq!(request.version(), PHONE_UNLOCK_VERSION);
+        assert_eq!(request.vault_id(), &VAULT_ID);
+        assert_eq!(request.action().as_str(), "unlock-keyring");
+        assert_eq!(request.expires_at(), 1_010);
+        assert_eq!(request.laptop_name(), "domen-laptop");
+    }
+
+    #[test]
+    fn matching_response_releases_zeroizing_share() {
+        let request = new_request();
+        let response = response_for(&request);
+
+        let validated = request
+            .accept_response(response, 1_009, &[CREDENTIAL_ID])
+            .unwrap();
+
+        assert_eq!(validated.credential_id(), CREDENTIAL_ID);
+        assert_eq!(
+            validated.phone_share().expose_secret(),
+            &[0x33; PHONE_SHARE_BYTES]
+        );
+        assert_eq!(
+            format!("{:?}", validated.phone_share()),
+            "PhoneShare([REDACTED])"
+        );
+    }
+
+    #[test]
+    fn expired_response_is_rejected() {
+        let request = new_request();
+        let response = response_for(&request);
+
+        assert!(matches!(
+            request.accept_response(response, 1_010, &[CREDENTIAL_ID]),
+            Err(PhoneFactorError::Expired)
+        ));
+    }
+
+    #[test]
+    fn response_must_match_the_active_request() {
+        let request = new_request();
+        let mut wrong_request_id = *request.request_id();
+        wrong_request_id[0] ^= 0xff;
+        let response = PhoneUnlockResponse::new(
+            request.version(),
+            *request.vault_id(),
+            wrong_request_id,
+            *request.challenge(),
+            request.action(),
+            CREDENTIAL_ID,
+            PhoneShare::new([0x33; PHONE_SHARE_BYTES]),
+        );
+
+        assert!(matches!(
+            request.accept_response(response, 1_001, &[CREDENTIAL_ID]),
+            Err(PhoneFactorError::BindingMismatch {
+                field: "request ID"
+            })
+        ));
+    }
+
+    #[test]
+    fn response_must_match_version_vault_and_challenge() {
+        let request = new_request();
+        let mut response = response_for(&request);
+        response.version = request.version().wrapping_add(1);
+        assert!(matches!(
+            request.accept_response(response, 1_001, &[CREDENTIAL_ID]),
+            Err(PhoneFactorError::UnsupportedVersion { .. })
+        ));
+
+        let request = new_request();
+        let mut response = response_for(&request);
+        response.vault_id[0] ^= 0xff;
+        assert!(matches!(
+            request.accept_response(response, 1_001, &[CREDENTIAL_ID]),
+            Err(PhoneFactorError::BindingMismatch { field: "vault ID" })
+        ));
+
+        let request = new_request();
+        let mut response = response_for(&request);
+        response.challenge[0] ^= 0xff;
+        assert!(matches!(
+            request.accept_response(response, 1_001, &[CREDENTIAL_ID]),
+            Err(PhoneFactorError::BindingMismatch { field: "challenge" })
+        ));
+    }
+
+    #[test]
+    fn response_requires_an_enrolled_credential() {
+        let request = new_request();
+        let response = response_for(&request);
+
+        assert!(matches!(
+            request.accept_response(response, 1_001, &[]),
+            Err(PhoneFactorError::CredentialNotEnrolled)
+        ));
+    }
+
+    #[test]
+    fn request_rejects_invalid_names_and_lifetimes() {
+        assert!(matches!(
+            PhoneUnlockRequest::new(VAULT_ID, "", 1_000, Duration::from_secs(10)),
+            Err(PhoneFactorError::InvalidLaptopName)
+        ));
+        assert!(matches!(
+            PhoneUnlockRequest::new(VAULT_ID, "laptop", 1_000, Duration::ZERO),
+            Err(PhoneFactorError::InvalidLifetime { .. })
+        ));
+        assert!(matches!(
+            PhoneUnlockRequest::new(VAULT_ID, "laptop", 1_000, Duration::from_secs(61)),
+            Err(PhoneFactorError::InvalidLifetime { .. })
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

- add a protocol-neutral phone-factor request/response boundary
- bind phone responses to a one-shot vault ID, request ID, challenge, action, expiry, and enrolled credential
- keep returned phone shares in zeroizing memory and expose transport-specific failures distinctly
- represent the planned factor explicitly as `Phone`
- document that Aliro codecs, cryptography, state machines, conformance fixtures, and platform transport live outside Factorseal

## Why

Factorseal needs a stable integration contract for phone-held vault-key material without embedding Aliro itself. This prepares vault and Secret Service work to use mock or future transport adapters while the standalone Rust Aliro implementation is developed independently.

Related to #13.

## Impact

This does not add phone enrollment, vault wrapping stanzas, BLE/Android integration, or an Aliro dependency. A future external adapter will implement `PhoneFactor` and return an authenticated, user-authorized response for Factorseal to validate.

## Validation

- `devenv test`
- `devenv shell cargo test --lib --all-features phone_factor`
- `devenv shell cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' devenv shell cargo doc --all-features --no-deps`
- `devenv shell cargo fmt --all -- --check`
- `git diff --check`
