### PR TITLE
linux: add Secret Service provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
         run: devenv shell -- shellcheck packaging/build-unix.sh packaging/linux/factorseal-start
       - name: Lint packaged POSIX helpers
         run: devenv shell -- shellcheck -s sh packaging/macos/factorseal-askpass
+      - name: Lint opt-in native acceptance runners
+        run: devenv shell -- shellcheck acceptance/linux.sh acceptance/macos.sh
+      - name: Evaluate the physical Linux acceptance app
+        run: nix --extra-experimental-features 'nix-command flakes' eval --raw .#apps.x86_64-linux.acceptance-linux.program
       - name: Run NixOS vault module VM test
         run: nix --extra-experimental-features 'nix-command flakes' build --print-build-logs .#checks.x86_64-linux.nixos-module
       - name: Build and inspect Linux package
@@ -96,12 +100,14 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Run tests
         run: cargo test --all-targets --all-features
-      - name: Parse the Windows askpass helper
+      - name: Parse Windows helpers and acceptance runner
         shell: pwsh
         run: |
-          $errors = $null
-          [void][System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path packaging/windows/factorseal-askpass.ps1), [ref]$null, [ref]$errors)
-          if ($errors.Count -gt 0) { $errors | ForEach-Object { Write-Output $_.ToString() }; throw 'askpass helper does not parse' }
+          foreach ($path in 'packaging/windows/factorseal-askpass.ps1', 'acceptance/windows.ps1') {
+            $errors = $null
+            [void][System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path $path), [ref]$null, [ref]$errors)
+            if ($errors.Count -gt 0) { $errors | ForEach-Object { Write-Output $_.ToString() }; throw "$path does not parse" }
+          }
       - name: Build and inspect Windows package
         shell: pwsh
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +454,15 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -1079,6 +1097,7 @@ dependencies = [
  "objc2-app-kit",
  "objc2-foundation",
  "rpassword",
+ "secret-service-protocol",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -1646,6 +1665,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -2772,6 +2792,20 @@ dependencies = [
  "generic-array",
  "pkcs8 0.10.2",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secret-service-protocol"
+version = "0.1.0"
+dependencies = [
+ "aes",
+ "cbc",
+ "getrandom 0.3.4",
+ "hkdf",
+ "num-bigint",
+ "sha2 0.10.9",
+ "thiserror",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdc70193dadb9d7287fa4b633f15f90c876915b31f6af17da307fc59c9859a8"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,12 +971,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
 dependencies = [
  "enumflags2_derive",
+ "serde",
 ]
 
 [[package]]
@@ -993,6 +1034,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "factorseal"
 version = "0.1.0"
 dependencies = [
@@ -1028,6 +1089,7 @@ dependencies = [
  "turso",
  "widestring",
  "windows 0.61.3",
+ "zbus",
  "zeroize",
 ]
 
@@ -1111,6 +1173,25 @@ name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-task"
@@ -1873,6 +1954,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ml-dsa"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,6 +2182,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,6 +2217,12 @@ checksum = "e3b7bb0ecf2e447b1f20ee94ee79ef6eed1e9d4b3c36ce1903b9dea3bf205523"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2312,6 +2420,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -2754,6 +2871,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2852,6 +2980,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2918,6 +3056,16 @@ checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
 dependencies = [
  "borsh",
  "serde_core",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3161,7 +3309,14 @@ version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
+ "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3173,7 +3328,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3221,6 +3376,18 @@ dependencies = [
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -3561,6 +3728,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3623,6 +3801,7 @@ checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
  "sha1_smol",
  "wasm-bindgen",
 ]
@@ -4130,6 +4309,9 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winresource"
@@ -4189,6 +4371,71 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.4",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4298,3 +4545,44 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zvariant"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.4",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.3",
+ "winnow 1.0.4",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ vault = [
     "dep:block2",
     "dep:ctrlc",
     "dep:dbus",
+    "dep:zbus",
     "dep:nix",
     "dep:nt-token",
     "dep:objc2",
@@ -66,7 +67,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
 sha2 = "0.10.9"
 thiserror = "2.0.12"
-tokio = { version = "1.47.1", features = ["rt", "sync"], optional = true }
+tokio = { version = "1.47.1", features = ["rt", "sync", "time"], optional = true }
 turso = { version = "0.8.0-pre.4", default-features = false, optional = true }
 zeroize = "1.8.1"
 
@@ -75,6 +76,7 @@ tempfile = "3.20.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = { version = "0.9.12", optional = true }
+zbus = { version = "5.14.0", default-features = false, features = ["tokio"], optional = true }
 nix = { version = "0.31.3", features = ["socket", "user"], optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ rust-version = "1.91"
 license = "Apache-2.0"
 repository = "https://github.com/factorseal/factorseal"
 
+[workspace]
+members = ["crates/secret-service-protocol"]
+resolver = "2"
+
 [features]
 default = ["vault", "cli", "hardware"]
 vault-client = ["dep:interprocess"]
@@ -27,6 +31,7 @@ vault = [
     "dep:block2",
     "dep:ctrlc",
     "dep:dbus",
+    "dep:secret-service-protocol",
     "dep:zbus",
     "dep:nix",
     "dep:nt-token",
@@ -63,6 +68,7 @@ hardware-enclave = { version = "0.2.10", default-features = false, features = ["
 hex = "0.4.3"
 ml-dsa = { version = "0.1.1", features = ["zeroize"], optional = true }
 rpassword = { version = "7.4.0", optional = true }
+secret-service-protocol = { path = "crates/secret-service-protocol", optional = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
 sha2 = "0.10.9"

--- a/README.md
+++ b/README.md
@@ -47,9 +47,12 @@ Factorseal is a broker backed by platform security hardware. It is not itself a
 Keychain or Windows Credential Manager API.
 
 In the Rust API, `Keyring` means the credential capability implemented by a
-`VaultClient`; it does not mean Linux's in-kernel `keyctl` keyrings. Native
-compatibility adapters such as the Linux Secret Service API, macOS Keychain,
-and Windows Credential Manager remain distinct platform interfaces.
+`VaultClient`; it does not mean Linux's in-kernel `keyctl` keyrings. On Linux,
+the unsealed service also exposes the standard `org.freedesktop.secrets`
+session-bus API, backed by the same encrypted vault. It is a single Secret
+Service provider, so do not run oo7, GNOME Keyring, or another provider that
+owns that name alongside it. macOS Keychain and Windows Credential Manager
+remain distinct platform interfaces.
 
 The first release is deliberately the user profile: a logged-in user, local
 application callers, interactive verification, and session-bound sealing. A
@@ -144,6 +147,12 @@ Still required before MVP release:
   physical hardware tests on every target, including verification of the
   OS-mediated Windows TPM prompt and modern Windows Hello UX.
 
+The opt-in physical-host runners and release-evidence procedure are in
+[`acceptance/`](acceptance/README.md). Passing a runner is evidence for one
+machine and event; release approval still needs the documented platform matrix.
+On NixOS/Linux, run the real-TPM suite with
+`nix run .#acceptance-linux -- --root /absolute/test/root --password-file /private/file`.
+
 No item in that list is implied complete merely because the shared Rust core
 builds on Linux.
 
@@ -186,6 +195,11 @@ bytes from standard input, or reads `--value-file`. `get` writes exact bytes
 without adding a newline. After replacing or upgrading the Factorseal binary,
 stop the service and run `factorseal grant-cli` to authorize the new executable
 digest.
+
+`factorseal destroy --yes-really-destroy` permanently deletes a **sealed**
+vault, including its TPM or Secure Enclave keys. It requires the nested factor
+and is intended for deliberate vault retirement and disposable native
+acceptance vaults; it is irreversible.
 
 ## Build and test
 

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -1,0 +1,90 @@
+# Native hardware and lifecycle acceptance
+
+These are opt-in acceptance runners for **physical** Linux, macOS, and Windows
+hosts. They are deliberately not part of normal CI: a virtual TPM, mocks, or a
+cloud macOS/Windows VM cannot demonstrate the device's actual TPM/Secure
+Enclave policy, user-verification prompt, or operating-system lifecycle path.
+
+Each runner creates a fresh vault through the release candidate binary. The
+macOS and Windows runners request native biometric/user verification at
+creation and unseal; Linux validates the TPM plus nested password. They verify:
+
+1. the backend recorded in `factorseal status` is the expected real hardware
+   backend (`tpm`/`tpm-bridge` on Linux and Windows, `secure-enclave` on macOS);
+2. the native transport permits an authorized local CLI to put, get, and delete
+   an exact-byte value;
+3. a real OS lock, sleep, shutdown-preparation, or session event causes the
+   live vault process to exit and the socket/pipe to become sealed;
+4. the same vault can be unsealed again and recover the stored value.
+
+Run the script from the account that will own the release installation. Pass a
+new, absolute `--root` and a private password file (`0600`, regular file). Do
+not use a production Factorseal root or password. A successful run leaves the
+test vault in place so an operator can inspect it. Add `--destroy-after` only
+after recording the result: it invokes the explicit, factor-gated irreversible
+`factorseal destroy --yes-really-destroy` command to delete both local data and
+native keys.
+
+## Linux
+
+Use the package-installed binary and ensure the user is in an active logind
+session with access to the real TPM. The runner asks you to lock the current
+session. It must be invoked from a terminal which survives the lock event.
+
+```console
+nix run .#acceptance-linux -- \
+  --root "$HOME/.local/share/factorseal-acceptance" \
+  --password-file "$HOME/.config/factorseal-acceptance-password"
+```
+
+The app builds and uses the repository's Nix package, including its TPM
+authorization-session patch. To test a separately installed release artifact,
+run `acceptance/linux.sh --factorseal /path/to/factorseal` with the same
+arguments instead.
+
+Also complete one installed-service run with `factorseal-start`, then lock the
+same logind session. Record the release-candidate hash, machine TPM model,
+distribution/version, firmware version, prompt behavior, and results for lock,
+suspend, logout, and shutdown. The NixOS virtual-TPM test is regression
+coverage only; it does not replace this protocol.
+
+## macOS
+
+Run against `/Applications/Factorseal.app/Contents/MacOS/factorseal` on a
+physical Secure Enclave-capable Mac. The runner asks you to lock/switch away or
+sleep the Mac, then waits for the vault to seal. Separately validate the signed
+and notarized app by logging in with its LaunchAgent enabled and confirming the
+askpass dialog works without a terminal.
+
+```console
+acceptance/macos.sh \
+  --factorseal /Applications/Factorseal.app/Contents/MacOS/factorseal \
+  --root "$HOME/Library/Application Support/Factorseal-acceptance" \
+  --password-file "$HOME/.factorseal-acceptance-password"
+```
+
+## Windows
+
+Run from an interactive, standard-user PowerShell session on a TPM 2.0 machine.
+The runner asks you to lock the current session, then waits for the vault
+process to exit. It must visibly exercise the supported CNG/Windows user
+verification policy. Separately install the signed release candidate, register
+the Scheduled Task template, log out/in, and verify the masked askpass dialog
+and Windows Hello UX.
+
+```powershell
+./acceptance/windows.ps1 `
+  -Factorseal 'C:\Program Files\Factorseal\factorseal.exe' `
+  -Root "$env:LOCALAPPDATA\Factorseal-acceptance" `
+  -PasswordFile "$env:USERPROFILE\.factorseal-acceptance-password"
+```
+
+## Release evidence
+
+For every supported OS/hardware combination, attach the redacted script output
+and a completed copy of [the acceptance record](results-template.md) to the
+release approval. A pass requires all lifecycle
+events named above, a verified real backend, an observed native user-verification
+prompt where policy requires one, and a successful re-unseal. Treat a missing
+prompt, software fallback, inability to seal, or a failure to re-unseal as a
+release blocker.

--- a/acceptance/linux.sh
+++ b/acceptance/linux.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# Opt-in physical TPM and lifecycle acceptance. See acceptance/README.md.
+set -eu
+
+usage() {
+    echo "usage: $0 --factorseal PATH --root ABSOLUTE_PATH --password-file PATH [--destroy-after]" >&2
+    exit "${1:-2}"
+}
+
+factorseal=
+root=
+password_file=
+destroy_after=false
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --factorseal) factorseal=${2:-}; shift 2 ;;
+        --root) root=${2:-}; shift 2 ;;
+        --password-file) password_file=${2:-}; shift 2 ;;
+        --destroy-after) destroy_after=true; shift ;;
+        --help|-h) usage 0 ;;
+        *) usage ;;
+    esac
+done
+
+[ -n "$factorseal" ] && [ -x "$factorseal" ] || usage
+[ -n "$root" ] && [ "${root#/}" != "$root" ] || usage
+[ ! -e "$root" ] || { echo "acceptance root already exists: $root" >&2; exit 2; }
+[ -n "$password_file" ] && [ -f "$password_file" ] || usage
+[ -n "${XDG_SESSION_ID:-}" ] || { echo "XDG_SESSION_ID is required for the logind lock test" >&2; exit 2; }
+
+vault_pid=
+cleanup() {
+    if [ -n "$vault_pid" ] && kill -0 "$vault_pid" 2>/dev/null; then
+        kill -TERM "$vault_pid" 2>/dev/null || true
+        wait "$vault_pid" || true
+    fi
+}
+trap cleanup EXIT HUP INT TERM
+
+status() { "$factorseal" --root "$root" status; }
+wait_for() {
+    expected=$1
+    attempts=0
+    while [ "$attempts" -lt 180 ]; do
+        if status 2>/dev/null | grep -q "\"state\": \"$expected\""; then return 0; fi
+        attempts=$((attempts + 1))
+        sleep 1
+    done
+    echo "vault did not become $expected within three minutes" >&2
+    return 1
+}
+
+wait_for_vault_exit() {
+    attempts=0
+    while kill -0 "$vault_pid" 2>/dev/null; do
+        if [ "$attempts" -ge 180 ]; then
+            echo "vault did not exit after the lifecycle event within three minutes" >&2
+            return 1
+        fi
+        attempts=$((attempts + 1))
+        sleep 1
+    done
+    wait "$vault_pid"
+    vault_pid=
+}
+
+"$factorseal" --root "$root" --password-file "$password_file" init
+status | grep -Eq '"hardware_backend": "tpm(-bridge)?"'
+
+"$factorseal" --root "$root" --password-file "$password_file" \
+    unseal --idle-seconds 3600 --maximum-seconds 3600 >"$root/acceptance-unseal.log" 2>&1 &
+vault_pid=$!
+wait_for unsealed
+printf '%s' 'hardware-lifecycle-acceptance' | "$factorseal" --root "$root" set acceptance --field value
+[ "$("$factorseal" --root "$root" get acceptance --field value)" = "hardware-lifecycle-acceptance" ]
+
+echo "Lock this exact logind session now (for example: loginctl lock-session \"$XDG_SESSION_ID\")."
+echo "The runner will fail if the real Lock signal does not seal the vault."
+printf 'Press Enter after initiating the lock event: '
+read -r _
+wait_for_vault_exit
+wait_for sealed
+if "$factorseal" --root "$root" get acceptance --field value >/dev/null 2>&1; then
+    echo "sealed vault returned a secret" >&2
+    exit 1
+fi
+
+"$factorseal" --root "$root" --password-file "$password_file" \
+    unseal --idle-seconds 3600 --maximum-seconds 3600 >"$root/acceptance-reunseal.log" 2>&1 &
+vault_pid=$!
+wait_for unsealed
+[ "$("$factorseal" --root "$root" get acceptance --field value)" = "hardware-lifecycle-acceptance" ]
+"$factorseal" --root "$root" delete acceptance --field value
+kill -TERM "$vault_pid"
+wait "$vault_pid"
+vault_pid=
+wait_for sealed
+
+if [ "$destroy_after" = true ]; then
+    "$factorseal" --root "$root" --password-file "$password_file" destroy --yes-really-destroy
+fi
+echo "Linux native hardware/lifecycle acceptance passed."

--- a/acceptance/macos.sh
+++ b/acceptance/macos.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# Opt-in physical Secure Enclave and lifecycle acceptance. See acceptance/README.md.
+set -eu
+
+usage() {
+    echo "usage: $0 --factorseal PATH --root ABSOLUTE_PATH --password-file PATH [--destroy-after]" >&2
+    exit "${1:-2}"
+}
+
+factorseal=
+root=
+password_file=
+destroy_after=false
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --factorseal) factorseal=${2:-}; shift 2 ;;
+        --root) root=${2:-}; shift 2 ;;
+        --password-file) password_file=${2:-}; shift 2 ;;
+        --destroy-after) destroy_after=true; shift ;;
+        --help|-h) usage 0 ;;
+        *) usage ;;
+    esac
+done
+
+[ -n "$factorseal" ] && [ -x "$factorseal" ] || usage
+[ -n "$root" ] && [ "${root#/}" != "$root" ] || usage
+[ ! -e "$root" ] || { echo "acceptance root already exists: $root" >&2; exit 2; }
+[ -n "$password_file" ] && [ -f "$password_file" ] || usage
+
+vault_pid=
+cleanup() {
+    if [ -n "$vault_pid" ] && kill -0 "$vault_pid" 2>/dev/null; then
+        kill -TERM "$vault_pid" 2>/dev/null || true
+        wait "$vault_pid" || true
+    fi
+}
+trap cleanup EXIT HUP INT TERM
+
+status() { "$factorseal" --root "$root" status; }
+wait_for() {
+    expected=$1
+    attempts=0
+    while [ "$attempts" -lt 180 ]; do
+        if status 2>/dev/null | grep -q "\"state\": \"$expected\""; then return 0; fi
+        attempts=$((attempts + 1))
+        sleep 1
+    done
+    echo "vault did not become $expected within three minutes" >&2
+    return 1
+}
+
+wait_for_vault_exit() {
+    attempts=0
+    while kill -0 "$vault_pid" 2>/dev/null; do
+        if [ "$attempts" -ge 180 ]; then
+            echo "vault did not exit after the lifecycle event within three minutes" >&2
+            return 1
+        fi
+        attempts=$((attempts + 1))
+        sleep 1
+    done
+    wait "$vault_pid"
+    vault_pid=
+}
+
+"$factorseal" --root "$root" --password-file "$password_file" init --biometric
+status | grep -q '"hardware_backend": "secure-enclave"'
+
+"$factorseal" --root "$root" --password-file "$password_file" \
+    unseal --idle-seconds 3600 --maximum-seconds 3600 >"$root/acceptance-unseal.log" 2>&1 &
+vault_pid=$!
+wait_for unsealed
+printf '%s' 'hardware-lifecycle-acceptance' | "$factorseal" --root "$root" set acceptance --field value
+[ "$("$factorseal" --root "$root" get acceptance --field value)" = "hardware-lifecycle-acceptance" ]
+
+echo "Lock/switch away from this session or put the Mac to sleep now."
+echo "The runner will fail if the real AppKit lifecycle notification does not seal the vault."
+printf 'Press Enter after initiating the lifecycle event: '
+read -r _
+wait_for_vault_exit
+wait_for sealed
+if "$factorseal" --root "$root" get acceptance --field value >/dev/null 2>&1; then
+    echo "sealed vault returned a secret" >&2
+    exit 1
+fi
+
+"$factorseal" --root "$root" --password-file "$password_file" \
+    unseal --idle-seconds 3600 --maximum-seconds 3600 >"$root/acceptance-reunseal.log" 2>&1 &
+vault_pid=$!
+wait_for unsealed
+[ "$("$factorseal" --root "$root" get acceptance --field value)" = "hardware-lifecycle-acceptance" ]
+"$factorseal" --root "$root" delete acceptance --field value
+kill -TERM "$vault_pid"
+wait "$vault_pid"
+vault_pid=
+wait_for sealed
+
+if [ "$destroy_after" = true ]; then
+    "$factorseal" --root "$root" --password-file "$password_file" destroy --yes-really-destroy
+fi
+echo "macOS native hardware/lifecycle acceptance passed."

--- a/acceptance/results-template.md
+++ b/acceptance/results-template.md
@@ -1,0 +1,29 @@
+# Native acceptance record
+
+Copy this file for each physical-host run and attach the completed, redacted
+record to the release approval. Do not include a nested factor, secret value,
+vault ID, device key ID, full username, or raw logs containing those values.
+
+| Field | Value |
+| --- | --- |
+| Release candidate version and SHA-256 | |
+| Date, operator, and independent reviewer | |
+| OS edition/version/build and architecture | |
+| Device model, firmware, and TPM/Secure Enclave details | |
+| Installed artifact signature/notarization verification | |
+| Factorseal recorded platform and hardware backend | |
+| Native verification prompt observed (where policy requires it) | |
+| Initial hardware-backed create and unseal | pass / fail |
+| Native IPC set/get/delete | pass / fail |
+| Lock/session switch seals the vault | pass / fail |
+| Sleep seals the vault before suspend | pass / fail |
+| Logout/disconnect seals the vault | pass / fail |
+| Shutdown preparation seals the vault | pass / fail |
+| Re-unseal recovers the value | pass / fail |
+| Installed login launcher and askpass flow | pass / fail |
+| Redacted runner output attached | yes / no |
+| Exceptions or failures | |
+
+A result is acceptable only when every applicable line passes. A missing native
+prompt, software fallback, lifecycle timeout, failed re-unseal, or unsigned
+artifact blocks the release until investigated and rerun.

--- a/acceptance/windows.ps1
+++ b/acceptance/windows.ps1
@@ -1,0 +1,90 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$Factorseal,
+    [Parameter(Mandatory = $true)][string]$Root,
+    [Parameter(Mandatory = $true)][string]$PasswordFile,
+    [switch]$DestroyAfter
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $Factorseal -PathType Leaf)) { throw "factorseal.exe is missing: $Factorseal" }
+if (-not [System.IO.Path]::IsPathRooted($Root)) { throw 'Root must be absolute' }
+if (Test-Path -LiteralPath $Root) { throw "Acceptance root already exists: $Root" }
+if (-not (Test-Path -LiteralPath $PasswordFile -PathType Leaf)) { throw "Password file is missing: $PasswordFile" }
+
+$service = $null
+
+function Get-Status {
+    $status = & $Factorseal --root $Root status
+    if ($LASTEXITCODE -ne 0) { throw 'factorseal status failed' }
+    $status | ConvertFrom-Json
+}
+
+function Wait-ForState([string]$Expected) {
+    for ($attempt = 0; $attempt -lt 180; $attempt++) {
+        try {
+            if ((Get-Status).state -eq $Expected) { return }
+        } catch { }
+        Start-Sleep -Seconds 1
+    }
+    throw "Vault did not become $Expected within three minutes"
+}
+
+try {
+& $Factorseal --root $Root --password-file $PasswordFile init --biometric
+if ($LASTEXITCODE -ne 0) { throw 'factorseal init failed' }
+$metadata = Get-Status
+if ($metadata.hardware_backend -notin @('tpm', 'tpm-bridge')) {
+    throw "Expected TPM backend, got $($metadata.hardware_backend)"
+}
+
+$service = Start-Process -FilePath $Factorseal -ArgumentList @(
+    '--root', $Root, '--password-file', $PasswordFile,
+    'unseal', '--idle-seconds', '3600', '--maximum-seconds', '3600'
+) -PassThru -RedirectStandardOutput (Join-Path $Root 'acceptance-unseal.log') -RedirectStandardError (Join-Path $Root 'acceptance-unseal-error.log')
+Wait-ForState 'unsealed'
+'hardware-lifecycle-acceptance' | & $Factorseal --root $Root set acceptance --field value
+if ($LASTEXITCODE -ne 0) { throw 'factorseal set failed' }
+$value = & $Factorseal --root $Root get acceptance --field value
+if ($LASTEXITCODE -ne 0 -or $value -ne 'hardware-lifecycle-acceptance') {
+    throw 'Keyring round trip failed'
+}
+
+Write-Host 'Lock this exact Windows session now (Win+L is suitable).'
+Write-Host 'The runner will fail if the real session lifecycle notification does not seal the vault.'
+[void](Read-Host 'Press Enter after initiating the lock event')
+$service.WaitForExit(180000)
+if (-not $service.HasExited) { throw 'Vault did not exit after the lifecycle event' }
+Wait-ForState 'sealed'
+$sealedValue = & $Factorseal --root $Root get acceptance --field value 2>$null
+if ($LASTEXITCODE -eq 0 -or $sealedValue) {
+    throw 'Sealed vault returned a secret'
+}
+
+$service = Start-Process -FilePath $Factorseal -ArgumentList @(
+    '--root', $Root, '--password-file', $PasswordFile,
+    'unseal', '--idle-seconds', '3600', '--maximum-seconds', '3600'
+) -PassThru -RedirectStandardOutput (Join-Path $Root 'acceptance-reunseal.log') -RedirectStandardError (Join-Path $Root 'acceptance-reunseal-error.log')
+Wait-ForState 'unsealed'
+$value = & $Factorseal --root $Root get acceptance --field value
+if ($LASTEXITCODE -ne 0 -or $value -ne 'hardware-lifecycle-acceptance') {
+    throw 'Hardware re-unseal did not recover the stored value'
+}
+& $Factorseal --root $Root delete acceptance --field value
+if ($LASTEXITCODE -ne 0) { throw 'factorseal delete failed' }
+Stop-Process -Id $service.Id
+$service.WaitForExit(30000)
+Wait-ForState 'sealed'
+
+if ($DestroyAfter) {
+    & $Factorseal --root $Root --password-file $PasswordFile destroy --yes-really-destroy
+    if ($LASTEXITCODE -ne 0) { throw 'factorseal destroy failed' }
+}
+Write-Host 'Windows native hardware/lifecycle acceptance passed.'
+} finally {
+    if ($null -ne $service -and -not $service.HasExited) {
+        Stop-Process -Id $service.Id -ErrorAction SilentlyContinue
+        $service.WaitForExit(30000)
+    }
+}

--- a/crates/secret-service-protocol/Cargo.toml
+++ b/crates/secret-service-protocol/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "secret-service-protocol"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.91"
+license = "Apache-2.0"
+description = "Pure-Rust Secret Service session negotiation and payload protection"
+repository = "https://github.com/factorseal/factorseal"
+
+[dependencies]
+aes = "0.8.4"
+cbc = { version = "0.1.2", features = ["alloc"] }
+getrandom = "0.3.3"
+hkdf = "0.12.4"
+num-bigint = "0.4.6"
+sha2 = "0.10.9"
+thiserror = "2.0.12"
+zeroize = "1.8.1"
+
+[lints.rust]
+unsafe_code = "deny"
+
+[lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+doc_markdown = "allow"
+missing_errors_doc = "allow"

--- a/crates/secret-service-protocol/src/lib.rs
+++ b/crates/secret-service-protocol/src/lib.rs
@@ -1,0 +1,199 @@
+//! Pure-Rust implementation of the Secret Service session wire protocol.
+//!
+//! This crate implements the algorithms named by the freedesktop Secret
+//! Service specification. It deliberately has no D-Bus, storage, or policy
+//! dependency: a service adapts [`SessionOutput`] and [`EncryptedPayload`] to
+//! its own wire types.
+
+use aes::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit, block_padding::Pkcs7};
+use hkdf::Hkdf;
+use num_bigint::BigUint;
+use sha2::Sha256;
+use thiserror::Error;
+use zeroize::Zeroizing;
+
+/// The unencrypted Secret Service session algorithm.
+pub const ALGORITHM_PLAIN: &str = "plain";
+/// The standard Secret Service DH/AES-CBC session algorithm.
+pub const ALGORITHM_DH: &str = "dh-ietf1024-sha256-aes128-cbc-pkcs7";
+
+const AES_KEY_BYTES: usize = 16;
+const AES_BLOCK_BYTES: usize = 16;
+const DH_BYTES: usize = 128;
+const DH_PRIME_BYTES: [u8; DH_BYTES] = [
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xC9, 0x0F, 0xDA, 0xA2, 0x21, 0x68, 0xC2, 0x34,
+    0xC4, 0xC6, 0x62, 0x8B, 0x80, 0xDC, 0x1C, 0xD1, 0x29, 0x02, 0x4E, 0x08, 0x8A, 0x67, 0xCC, 0x74,
+    0x02, 0x0B, 0xBE, 0xA6, 0x3B, 0x13, 0x9B, 0x22, 0x51, 0x4A, 0x08, 0x79, 0x8E, 0x34, 0x04, 0xDD,
+    0xEF, 0x95, 0x19, 0xB3, 0xCD, 0x3A, 0x43, 0x1B, 0x30, 0x2B, 0x0A, 0x6D, 0xF2, 0x5F, 0x14, 0x37,
+    0x4F, 0xE1, 0x35, 0x6D, 0x6D, 0x51, 0xC2, 0x45, 0xE4, 0x85, 0xB5, 0x76, 0x62, 0x5E, 0x7E, 0xC6,
+    0xF4, 0x4C, 0x42, 0xE9, 0xA6, 0x37, 0xED, 0x6B, 0x0B, 0xFF, 0x5C, 0xB6, 0xF4, 0x06, 0xB7, 0xED,
+    0xEE, 0x38, 0x6B, 0xFB, 0x5A, 0x89, 0x9F, 0xA5, 0xAE, 0x9F, 0x24, 0x11, 0x7C, 0x4B, 0x1F, 0xE6,
+    0x49, 0x28, 0x66, 0x51, 0xEC, 0xE6, 0x53, 0x81, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+];
+
+/// Reply payload for an `OpenSession` call.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SessionOutput {
+    /// The D-Bus reply is an empty string variant.
+    Plain,
+    /// The D-Bus reply is the server's 1024-bit DH public key byte array.
+    DhPublicKey(Vec<u8>),
+}
+
+/// A Secret Service secret payload after session encryption.
+#[derive(Clone)]
+pub struct EncryptedPayload {
+    /// Empty for plain sessions; a fresh AES-CBC IV for DH sessions.
+    pub parameters: Vec<u8>,
+    /// The plaintext or encrypted payload. It is wiped when dropped.
+    pub value: Zeroizing<Vec<u8>>,
+}
+
+/// An error returned while negotiating or using a session.
+#[derive(Debug, Error)]
+pub enum ProtocolError {
+    #[error("unsupported Secret Service session algorithm `{0}")]
+    UnsupportedAlgorithm(String),
+    #[error("invalid Secret Service DH public key")]
+    InvalidDhPublicKey,
+    #[error("invalid Secret Service AES initialization vector")]
+    InvalidInitializationVector,
+    #[error("invalid encrypted Secret Service payload")]
+    InvalidCiphertext,
+    #[error("randomness unavailable: {0}")]
+    Randomness(String),
+}
+
+impl From<getrandom::Error> for ProtocolError {
+    fn from(error: getrandom::Error) -> Self {
+        Self::Randomness(error.to_string())
+    }
+}
+
+/// One negotiated session. Key material is zeroized when dropped.
+#[derive(Clone)]
+pub struct Session {
+    key: Option<Zeroizing<[u8; AES_KEY_BYTES]>>,
+}
+
+impl Session {
+    /// Negotiate a server-side Secret Service session.
+    pub fn open(algorithm: &str, input: &[u8]) -> Result<(Self, SessionOutput), ProtocolError> {
+        match algorithm {
+            ALGORITHM_PLAIN if input.is_empty() => Ok((Self { key: None }, SessionOutput::Plain)),
+            ALGORITHM_PLAIN => Err(ProtocolError::InvalidDhPublicKey),
+            ALGORITHM_DH => Self::open_dh(input),
+            other => Err(ProtocolError::UnsupportedAlgorithm(other.to_owned())),
+        }
+    }
+
+    /// Encrypt a payload for this session.
+    pub fn encrypt(&self, value: &[u8]) -> Result<EncryptedPayload, ProtocolError> {
+        let Some(key) = &self.key else {
+            return Ok(EncryptedPayload {
+                parameters: Vec::new(),
+                value: Zeroizing::new(value.to_vec()),
+            });
+        };
+        let mut iv = [0_u8; AES_BLOCK_BYTES];
+        getrandom::fill(&mut iv)?;
+        let value = cbc::Encryptor::<aes::Aes128>::new(key.as_ref().into(), (&iv).into())
+            .encrypt_padded_vec_mut::<Pkcs7>(value);
+        Ok(EncryptedPayload {
+            parameters: iv.to_vec(),
+            value: Zeroizing::new(value),
+        })
+    }
+
+    /// Decrypt a payload from this session.
+    pub fn decrypt(
+        &self,
+        parameters: &[u8],
+        value: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, ProtocolError> {
+        let Some(key) = &self.key else {
+            if parameters.is_empty() {
+                return Ok(Zeroizing::new(value.to_vec()));
+            }
+            return Err(ProtocolError::InvalidInitializationVector);
+        };
+        if parameters.len() != AES_BLOCK_BYTES {
+            return Err(ProtocolError::InvalidInitializationVector);
+        }
+        cbc::Decryptor::<aes::Aes128>::new(key.as_ref().into(), parameters.into())
+            .decrypt_padded_vec_mut::<Pkcs7>(value)
+            .map(Zeroizing::new)
+            .map_err(|_| ProtocolError::InvalidCiphertext)
+    }
+
+    fn open_dh(input: &[u8]) -> Result<(Self, SessionOutput), ProtocolError> {
+        let prime = BigUint::from_bytes_be(&DH_PRIME_BYTES);
+        let client_public = BigUint::from_bytes_be(input);
+        let generator = BigUint::from(2_u8);
+        if client_public < generator || client_public > &prime - &generator {
+            return Err(ProtocolError::InvalidDhPublicKey);
+        }
+        let mut private_bytes = Zeroizing::new([0_u8; DH_BYTES]);
+        getrandom::fill(&mut *private_bytes)?;
+        let private = BigUint::from_bytes_be(&*private_bytes);
+        let server_public = generator.modpow(&private, &prime);
+        let shared = client_public.modpow(&private, &prime);
+        let shared = pad_dh_value(&shared)?;
+        let mut key = Zeroizing::new([0_u8; AES_KEY_BYTES]);
+        Hkdf::<Sha256>::new(None, &shared)
+            .expand(&[], &mut *key)
+            .expect("AES-128 key length is valid");
+        Ok((
+            Self { key: Some(key) },
+            SessionOutput::DhPublicKey(pad_dh_value(&server_public)?),
+        ))
+    }
+}
+
+fn pad_dh_value(value: &BigUint) -> Result<Vec<u8>, ProtocolError> {
+    let value = value.to_bytes_be();
+    if value.len() > DH_BYTES {
+        return Err(ProtocolError::InvalidDhPublicKey);
+    }
+    let mut padded = vec![0_u8; DH_BYTES - value.len()];
+    padded.extend(value);
+    Ok(padded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dh_session_round_trips_and_interoperates_with_client_derivation() {
+        let prime = BigUint::from_bytes_be(&DH_PRIME_BYTES);
+        let generator = BigUint::from(2_u8);
+        let private = BigUint::from(42_u8);
+        let public = generator.modpow(&private, &prime);
+        let (session, SessionOutput::DhPublicKey(server_public)) =
+            Session::open(ALGORITHM_DH, &pad_dh_value(&public).unwrap()).unwrap()
+        else {
+            panic!("expected DH output");
+        };
+        let shared = BigUint::from_bytes_be(&server_public).modpow(&private, &prime);
+        let mut client_key = [0_u8; AES_KEY_BYTES];
+        Hkdf::<Sha256>::new(None, &pad_dh_value(&shared).unwrap())
+            .expand(&[], &mut client_key)
+            .unwrap();
+        let encrypted = session.encrypt(b"secret").unwrap();
+        let plain = cbc::Decryptor::<aes::Aes128>::new(
+            (&client_key).into(),
+            encrypted.parameters.as_slice().into(),
+        )
+        .decrypt_padded_vec_mut::<Pkcs7>(&encrypted.value)
+        .unwrap();
+        assert_eq!(plain, b"secret");
+        assert_eq!(
+            session
+                .decrypt(&encrypted.parameters, &encrypted.value)
+                .unwrap()
+                .as_slice(),
+            b"secret"
+        );
+    }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,35 @@
         }
       );
 
+      # This is intentionally an app rather than a flake check: it uses the
+      # host's real TPM and asks the operator to trigger a session-lock event.
+      # `nix run` builds the same patched Linux package that release artifacts
+      # use, then runs the opt-in physical acceptance suite against it.
+      apps = forLinuxSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          acceptance = pkgs.writeShellApplication {
+            name = "factorseal-acceptance-linux";
+            runtimeInputs = [
+              pkgs.coreutils
+              pkgs.gnugrep
+            ];
+            text = ''
+              exec ${pkgs.dash}/bin/dash ${./acceptance/linux.sh} \\
+                --factorseal ${self.packages.${system}.factorseal}/bin/factorseal \\
+                "$@"
+            '';
+          };
+        in
+        {
+          acceptance-linux = {
+            type = "app";
+            program = "${acceptance}/bin/factorseal-acceptance-linux";
+          };
+        }
+      );
+
       nixosModules = {
         default = import ./nix/modules/factorseal.nix;
         factorseal = self.nixosModules.default;

--- a/nix/modules/factorseal.nix
+++ b/nix/modules/factorseal.nix
@@ -75,6 +75,10 @@ in
     systemd.user.services.factorseal = {
       description = "Factorseal per-user vault service";
       documentation = [ "https://github.com/factorseal/factorseal" ];
+      # A user manager does not necessarily inherit the graphical session's
+      # environment. The broker needs this address to publish the standard
+      # org.freedesktop.secrets service on the per-user bus.
+      environment.DBUS_SESSION_BUS_ADDRESS = "unix:path=%t/bus";
 
       # Deliberately no wantedBy: Linux requires an interactive password for
       # every unseal session. factorseal-start performs that handoff.

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -17,6 +17,7 @@ rustPlatform.buildRustPackage {
     fileset = lib.fileset.unions [
       ../Cargo.lock
       ../Cargo.toml
+      ../crates
       ../nix/patches/hardware-enclave-tpm-auth-sessions.patch
       ../src
     ];

--- a/nix/tests/factorseal.nix
+++ b/nix/tests/factorseal.nix
@@ -49,7 +49,7 @@ pkgs.testers.runNixOSTest {
   };
 
   testScript = ''
-    alice_prefix = "runuser -u alice -- env HOME=/home/alice XDG_RUNTIME_DIR=/run/user/1000"
+    alice_prefix = "runuser -u alice -- env HOME=/home/alice XDG_RUNTIME_DIR=/run/user/1000 DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus"
     root = "/home/alice/.local/share/factorseal"
     runtime = "/run/user/1000/factorseal"
     password_file = f"{runtime}/session-password"
@@ -125,6 +125,11 @@ pkgs.testers.runNixOSTest {
         machine.succeed("systemd-inhibit --list | grep -F Factorseal")
         machine.succeed(f"test $(stat -c %a {socket}) = 600")
         machine.succeed(f"test $(stat -c %a {root}) = 700")
+        as_alice(
+            "busctl --user introspect org.freedesktop.secrets "
+            "/org/freedesktop/secrets org.freedesktop.Secret.Service "
+            "| grep -w OpenSession"
+        )
 
     with subtest("idle expiry seals the vault and removes the socket"):
         # The 5 s idle lease above is what ends this; wait for the outcome

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -29,6 +29,8 @@ requires glibc, D-Bus, and `tpm2-tss`; it is not a universal static binary and
 must not be published from a Nix development shell whose loader paths point
 into `/nix/store`. Physical TPM/Secure Enclave acceptance is separate from
 archive smoke testing.
+Use the release-candidate runners in [`acceptance/`](../acceptance/README.md)
+on physical hosts and attach their redacted output to the release approval.
 
 ## Obtaining the nested factor
 

--- a/packaging/linux/factorseal.service.in
+++ b/packaging/linux/factorseal.service.in
@@ -4,6 +4,7 @@ Documentation=https://github.com/factorseal/factorseal
 
 [Service]
 Type=simple
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus
 ExecStart=@INSTALL_DIR@/factorseal --password-file=%t/factorseal/session-password unseal
 Restart=no
 UMask=0077

--- a/src/bin/factorseal.rs
+++ b/src/bin/factorseal.rs
@@ -124,6 +124,13 @@ enum Command {
         field: Option<String>,
     },
 
+    /// Permanently delete this vault and both of its hardware keys.
+    Destroy {
+        /// Required acknowledgement because this cannot be undone.
+        #[arg(long)]
+        yes_really_destroy: bool,
+    },
+
     /// Reauthorize this exact Factorseal executable after an upgrade.
     GrantCli,
 
@@ -162,6 +169,17 @@ enum CliError {
 
     #[error("keyring entry was not found")]
     KeyringEntryNotFound,
+
+    #[error("the vault is still unsealed; stop its service before destroying it")]
+    VaultIsLive,
+
+    #[error(
+        "could not prove the vault is sealed; pass the correct --socket after stopping its service"
+    )]
+    VaultStateUnknown,
+
+    #[error("refusing to destroy a vault without --yes-really-destroy")]
+    DestroyConfirmationRequired,
 
     #[error("could not identify the Factorseal executable: {0}")]
     CurrentExecutable(String),
@@ -231,6 +249,9 @@ fn run(cli: Cli) -> Result<(), CliError> {
         } => set_keyring_value(&root, socket, item, field, value_file.as_deref()),
         Command::Get { item, field } => get_keyring_value(&root, socket, item, field),
         Command::Delete { item, field } => delete_keyring_value(&root, socket, item, field),
+        Command::Destroy { yes_really_destroy } => {
+            destroy_vault(&root, socket, factor, yes_really_destroy)
+        }
         Command::GrantCli => grant_cli(&root, factor),
         Command::GrantSecretspec {
             executable,
@@ -363,6 +384,27 @@ fn delete_keyring_value(
     if !existed {
         return Err(CliError::KeyringEntryNotFound);
     }
+    Ok(())
+}
+
+fn destroy_vault(
+    root: &Path,
+    socket: Option<&Path>,
+    factor: FactorSource<'_>,
+    confirmed: bool,
+) -> Result<(), CliError> {
+    if !confirmed {
+        return Err(CliError::DestroyConfirmationRequired);
+    }
+    let device = Vault::inspect(root)?;
+    match live_state(root, socket, &device) {
+        "sealed" => {}
+        "unsealed" => return Err(CliError::VaultIsLive),
+        _ => return Err(CliError::VaultStateUnknown),
+    }
+    let password = read_factor(factor, false)?;
+    Vault::destroy(root, UnsealFactor::Password(&password))?;
+    println!("Destroyed Factorseal vault at {}", root.display());
     Ok(())
 }
 

--- a/src/vault/linux.rs
+++ b/src/vault/linux.rs
@@ -61,7 +61,10 @@ impl LinuxVaultOptions {
 /// Caller identity comes from `SO_PEERCRED` and `/proc/<pid>/exe`; no identity
 /// field from the request is trusted. This function blocks until explicit
 /// lock, lease expiry, session lock, suspend, shutdown, SIGINT, or SIGTERM.
-pub fn serve_linux_vault(service: &VaultService, options: &LinuxVaultOptions) -> VaultResult<()> {
+pub fn serve_linux_vault(
+    service: &Arc<VaultService>,
+    options: &LinuxVaultOptions,
+) -> VaultResult<()> {
     validate_socket_options("Linux", &options.socket_path, options.poll_interval)?;
     prepare_socket_path(&options.socket_path)?;
     let listener = UnixListener::bind(&options.socket_path)
@@ -89,14 +92,32 @@ pub fn serve_linux_vault(service: &VaultService, options: &LinuxVaultOptions) ->
     // Every exit from the loop discards the hardware-unwrapped keys, including
     // the error exits. Returning `?` straight out of the loop skipped the lock
     // and left them to whatever the caller did next.
-    let served = accept_until_sealed(
-        service,
-        options,
-        &listener,
-        &stopping,
-        &lifecycle_seal_requested,
-        lifecycle_monitor.as_ref(),
-    );
+    // A systemd user manager provides the session bus on desktop Linux. Keep
+    // headless CLI/acceptance runs functional when there is no user bus to
+    // publish the optional desktop compatibility interface on.
+    let has_session_bus = std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_some();
+    let served = std::thread::scope(|scope| {
+        let secret_service = has_session_bus.then(|| {
+            let service = Arc::clone(service);
+            let stopping = Arc::clone(&stopping);
+            scope.spawn(move || super::secret_service::serve_secret_service(service, stopping))
+        });
+        let result = accept_until_sealed(
+            service,
+            options,
+            &listener,
+            &stopping,
+            &lifecycle_seal_requested,
+            lifecycle_monitor.as_ref(),
+        );
+        stopping.store(true, Ordering::Release);
+        if let Some(thread) = secret_service {
+            thread
+                .join()
+                .map_err(|_| VaultError::Protocol("Secret Service thread panicked".to_owned()))??;
+        }
+        result
+    });
     let sealed = service.seal();
     served.and(sealed)
 }
@@ -399,8 +420,9 @@ mod tests {
         let root = directory.path().join("factorseal");
         let unsealed = Vault::create_for_test(&root).unwrap();
         let store = VaultStore::open(&root, unsealed).unwrap();
-        let service =
-            VaultService::new(store, unix_time().unwrap(), UnsealLeasePolicy::default()).unwrap();
+        let service = Arc::new(
+            VaultService::new(store, unix_time().unwrap(), UnsealLeasePolicy::default()).unwrap(),
+        );
 
         // A panicking request poisons the request-state mutex, so the first
         // expire_if_needed of the loop fails rather than returning cleanly.

--- a/src/vault/linux.rs
+++ b/src/vault/linux.rs
@@ -42,6 +42,9 @@ pub struct LinuxVaultOptions {
     /// monitoring when this process belongs to a logind session. Disable only
     /// when an embedding process supplies equivalent hooks.
     pub install_lifecycle_monitor: bool,
+    /// Publish `org.freedesktop.secrets` on the session bus. Disable only for
+    /// embedded and socket-only test servers.
+    pub install_secret_service: bool,
 }
 
 impl LinuxVaultOptions {
@@ -52,6 +55,7 @@ impl LinuxVaultOptions {
             poll_interval: DEFAULT_POLL_INTERVAL,
             install_signal_handler: true,
             install_lifecycle_monitor: true,
+            install_secret_service: true,
         }
     }
 }
@@ -95,7 +99,8 @@ pub fn serve_linux_vault(
     // A systemd user manager provides the session bus on desktop Linux. Keep
     // headless CLI/acceptance runs functional when there is no user bus to
     // publish the optional desktop compatibility interface on.
-    let has_session_bus = std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_some();
+    let has_session_bus =
+        options.install_secret_service && std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_some();
     let served = std::thread::scope(|scope| {
         let secret_service = has_session_bus.then(|| {
             let service = Arc::clone(service);
@@ -436,6 +441,7 @@ mod tests {
             poll_interval: Duration::from_millis(5),
             install_signal_handler: false,
             install_lifecycle_monitor: false,
+            install_secret_service: false,
         };
         assert!(serve_linux_vault(&service, &options).is_err());
         assert!(
@@ -450,6 +456,7 @@ mod tests {
         let options = LinuxVaultOptions::new("/run/user/1000/factorseal/factorseal.sock");
         assert!(options.install_signal_handler);
         assert!(options.install_lifecycle_monitor);
+        assert!(options.install_secret_service);
     }
 
     #[test]
@@ -495,6 +502,7 @@ mod tests {
             poll_interval: Duration::from_millis(5),
             install_signal_handler: false,
             install_lifecycle_monitor: false,
+            install_secret_service: false,
         };
         let server_service = Arc::clone(&service);
         let server = std::thread::spawn(move || serve_linux_vault(&server_service, &options));

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -24,6 +24,8 @@ mod transport;
 
 #[cfg(all(feature = "vault", target_os = "linux"))]
 mod linux;
+#[cfg(all(feature = "vault", target_os = "linux"))]
+mod secret_service;
 
 #[cfg(all(feature = "vault", target_os = "macos"))]
 mod macos;

--- a/src/vault/seal.rs
+++ b/src/vault/seal.rs
@@ -192,6 +192,23 @@ impl Vault {
         discard_initialization_with_factory(root.as_ref(), &PlatformProtectorFactory, true)
     }
 
+    /// Permanently destroy a sealed vault after proving possession of its
+    /// nested factor.
+    ///
+    /// This deletes both native hardware keys and the local vault directory.
+    /// Callers must first stop any running vault service; destruction is an
+    /// explicit recovery or disposable-test operation, not a substitute for
+    /// sealing a live vault.
+    #[cfg(feature = "hardware")]
+    pub fn destroy(root: impl AsRef<Path>, factor: UnsealFactor<'_>) -> VaultResult<()> {
+        let root = root.as_ref();
+        // Do not let possession of the local vault directory alone destroy a
+        // user's TPM/Secure Enclave keys. A successful unseal also validates
+        // the recorded public device identity before anything is deleted.
+        let _verified = Self::unseal(root, factor)?;
+        Self::discard_initialization(root)
+    }
+
     /// Delete an incomplete vault and its platform keys through an injected
     /// platform adapter.
     #[cfg(feature = "key-protection")]
@@ -200,6 +217,21 @@ impl Vault {
         factory: &dyn KeyProtectorFactory,
     ) -> VaultResult<()> {
         discard_initialization_with_factory(root.as_ref(), factory, false)
+    }
+
+    /// Permanently destroy a vault created through an injected key protector.
+    ///
+    /// This is the portable counterpart of [`Self::destroy`]. The caller must
+    /// have stopped every live service using `root` before calling it.
+    #[cfg(feature = "key-protection")]
+    pub fn destroy_with_key_protector(
+        root: impl AsRef<Path>,
+        factor: UnsealFactor<'_>,
+        factory: &dyn KeyProtectorFactory,
+    ) -> VaultResult<()> {
+        let root = root.as_ref();
+        let _verified = Self::unseal_with_key_protector(root, factor, factory)?;
+        discard_initialization_with_factory(root, factory, false)
     }
 
     /// Create a vault with the native desktop hardware adapter.
@@ -1197,6 +1229,38 @@ mod tests {
         // failure path can call it without checking first.
         Vault::discard_initialization_with_key_protector(&root, &TestProtectorFactory).unwrap();
         Vault::create_for_test(&root).unwrap();
+    }
+
+    #[test]
+    fn destroy_requires_the_factor_and_removes_a_completed_vault() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("factorseal");
+        Vault::create_with_key_protector(
+            &root,
+            VaultPlatform::Android,
+            UnsealFactor::Password(b"acceptance-factor"),
+            false,
+            &TestProtectorFactory,
+        )
+        .unwrap();
+
+        assert!(
+            Vault::destroy_with_key_protector(
+                &root,
+                UnsealFactor::Password(b"wrong-factor"),
+                &TestProtectorFactory,
+            )
+            .is_err()
+        );
+        assert!(root.exists());
+
+        Vault::destroy_with_key_protector(
+            &root,
+            UnsealFactor::Password(b"acceptance-factor"),
+            &TestProtectorFactory,
+        )
+        .unwrap();
+        assert!(!root.exists());
     }
 
     #[test]

--- a/src/vault/secret_service.rs
+++ b/src/vault/secret_service.rs
@@ -5,6 +5,10 @@
 //! session bus already authenticates peers as the current desktop user, which
 //! is the same boundary provided by the other Secret Service implementations.
 
+#![allow(clippy::needless_pass_by_value, clippy::unused_self)]
+// zbus interface methods must own decoded D-Bus arguments, including headers
+// and object paths; changing these signatures to references breaks dispatch.
+
 use std::collections::HashMap;
 use std::sync::{
     Arc, Mutex,

--- a/src/vault/secret_service.rs
+++ b/src/vault/secret_service.rs
@@ -1,0 +1,690 @@
+//! Linux `org.freedesktop.secrets` adapter backed by the live Factorseal vault.
+//!
+//! The adapter is deliberately part of the unsealed vault process: it has no
+//! database access of its own and disappears as soon as the vault seals.  The
+//! session bus already authenticates peers as the current desktop user, which
+//! is the same boundary provided by the other Secret Service implementations.
+
+use std::collections::HashMap;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use zbus::object_server::ObjectServer;
+use zbus::zvariant::{OwnedObjectPath, OwnedValue};
+use zbus::{Connection, fdo, interface};
+
+use super::linux::linux_caller_identity_for_executable;
+use super::{
+    GrantPermission, VaultAction, VaultError, VaultRequest, VaultResponseBody, VaultResult,
+    VaultService, WireSecret, WireSecretAddress,
+};
+
+const BUS_NAME: &str = "org.freedesktop.secrets";
+const SERVICE_PATH: &str = "/org/freedesktop/secrets";
+const COLLECTION_PATH: &str = "/org/freedesktop/secrets/collection/factorseal";
+const DEFAULT_ALIAS_PATH: &str = "/org/freedesktop/secrets/aliases/default";
+const ITEM_PREFIX: &str = "/org/freedesktop/secrets/collection/factorseal/";
+const SESSION_PREFIX: &str = "/org/freedesktop/secrets/session/";
+const NAMESPACE: &[u8] = b"factorseal/secret-service/v1";
+const INDEX_ITEM: &str = "secret-service-index";
+const INDEX_VERSION: u8 = 1;
+
+type Secret = (OwnedObjectPath, Vec<u8>, Vec<u8>, String);
+type Properties = HashMap<String, OwnedValue>;
+
+/// Serve Secret Service until `stopping` is set or the vault seals.
+///
+/// The internal Factorseal binary is granted this namespace and mediates the
+/// session-bus API. This is intentionally separate from grants issued to IPC
+/// clients: a session-bus client never receives the vault socket capability.
+pub(crate) fn serve_secret_service(
+    service: Arc<VaultService>,
+    stopping: Arc<AtomicBool>,
+) -> VaultResult<()> {
+    let executable = std::env::current_exe().map_err(|error| {
+        VaultError::Protocol(format!("could not resolve Factorseal executable: {error}"))
+    })?;
+    let caller = linux_caller_identity_for_executable(executable)?;
+    service.authorize_namespace(
+        &caller,
+        NAMESPACE,
+        [
+            GrantPermission::Get,
+            GrantPermission::Put,
+            GrantPermission::Delete,
+            GrantPermission::Seal,
+        ],
+        None,
+        unix_time(),
+    )?;
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| {
+            VaultError::Protocol(format!("could not start Secret Service runtime: {error}"))
+        })?;
+    runtime.block_on(async move {
+        let store = Store {
+            service: Arc::clone(&service),
+            caller,
+        };
+        let agent = Arc::new(Agent::load(store)?);
+        let connection = Connection::session().await.map_err(dbus_error)?;
+        connection
+            .request_name_with_flags(BUS_NAME, zbus::fdo::RequestNameFlags::DoNotQueue.into())
+            .await
+            .map_err(dbus_error)?;
+        let server = connection.object_server();
+        server
+            .at(
+                SERVICE_PATH,
+                Service {
+                    agent: Arc::clone(&agent),
+                },
+            )
+            .await
+            .map_err(dbus_error)?;
+        server
+            .at(
+                COLLECTION_PATH,
+                Collection {
+                    agent: Arc::clone(&agent),
+                },
+            )
+            .await
+            .map_err(dbus_error)?;
+        server
+            .at(
+                DEFAULT_ALIAS_PATH,
+                Collection {
+                    agent: Arc::clone(&agent),
+                },
+            )
+            .await
+            .map_err(dbus_error)?;
+        for id in agent.item_ids()? {
+            let path = item_path(&id).map_err(|error| VaultError::Protocol(error.to_string()))?;
+            server
+                .at(
+                    path,
+                    Item {
+                        agent: Arc::clone(&agent),
+                        id,
+                    },
+                )
+                .await
+                .map_err(dbus_error)?;
+        }
+
+        while !stopping.load(Ordering::Acquire) && !service.expire_if_needed(unix_time())? {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        Ok(())
+    })
+}
+
+#[derive(Clone)]
+struct Store {
+    service: Arc<VaultService>,
+    caller: super::CallerIdentity,
+}
+
+impl Store {
+    fn call(&self, action: VaultAction) -> VaultResult<VaultResponseBody> {
+        let request = VaultRequest::new(action)?;
+        self.service
+            .handle(&self.caller, request, unix_time())
+            .result
+            .map_err(|error| VaultError::Protocol(error.message))
+    }
+
+    fn get(&self, item: impl Into<String>) -> VaultResult<Option<Vec<u8>>> {
+        let response = self.call(VaultAction::Get {
+            namespace: NAMESPACE.to_vec(),
+            address: WireSecretAddress::new(item, None),
+        })?;
+        match response {
+            VaultResponseBody::Secret { value } => Ok(value.map(|value| value.expose().to_vec())),
+            _ => Err(VaultError::Protocol(
+                "unexpected Secret Service vault response".to_owned(),
+            )),
+        }
+    }
+
+    fn put(&self, item: impl Into<String>, value: Vec<u8>) -> VaultResult<()> {
+        match self.call(VaultAction::Put {
+            namespace: NAMESPACE.to_vec(),
+            address: WireSecretAddress::new(item, None),
+            value: WireSecret::new(value),
+            evict_at: None,
+        })? {
+            VaultResponseBody::Stored => Ok(()),
+            _ => Err(VaultError::Protocol(
+                "unexpected Secret Service vault response".to_owned(),
+            )),
+        }
+    }
+
+    fn delete(&self, item: impl Into<String>) -> VaultResult<()> {
+        match self.call(VaultAction::Delete {
+            namespace: NAMESPACE.to_vec(),
+            address: WireSecretAddress::new(item, None),
+        })? {
+            VaultResponseBody::Deleted { .. } => Ok(()),
+            _ => Err(VaultError::Protocol(
+                "unexpected Secret Service vault response".to_owned(),
+            )),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+struct Index {
+    version: u8,
+    items: Vec<IndexItem>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct IndexItem {
+    id: String,
+    label: String,
+    attributes: HashMap<String, String>,
+    content_type: String,
+    created: u64,
+    modified: u64,
+}
+
+struct Agent {
+    store: Store,
+    index: Mutex<Index>,
+    sessions: Mutex<HashMap<String, String>>,
+}
+
+impl Agent {
+    fn load(store: Store) -> VaultResult<Self> {
+        let index = match store.get(INDEX_ITEM)? {
+            Some(bytes) => serde_json::from_slice::<Index>(&bytes).map_err(|error| {
+                VaultError::InvalidData(format!("invalid Secret Service index: {error}"))
+            })?,
+            None => Index {
+                version: INDEX_VERSION,
+                items: Vec::new(),
+            },
+        };
+        if index.version != INDEX_VERSION {
+            return Err(VaultError::InvalidData(
+                "unsupported Secret Service index version".to_owned(),
+            ));
+        }
+        Ok(Self {
+            store,
+            index: Mutex::new(index),
+            sessions: Mutex::new(HashMap::new()),
+        })
+    }
+
+    fn item_ids(&self) -> VaultResult<Vec<String>> {
+        Ok(self
+            .index
+            .lock()
+            .map_err(|_| VaultError::WorkerUnavailable)?
+            .items
+            .iter()
+            .map(|item| item.id.clone())
+            .collect())
+    }
+
+    fn item(&self, id: &str) -> fdo::Result<IndexItem> {
+        self.index
+            .lock()
+            .map_err(poisoned)?
+            .items
+            .iter()
+            .find(|item| item.id == id)
+            .cloned()
+            .ok_or_else(|| no_item(id))
+    }
+
+    fn all_items(&self) -> fdo::Result<Vec<IndexItem>> {
+        Ok(self.index.lock().map_err(poisoned)?.items.clone())
+    }
+
+    fn save_index(&self, index: &Index) -> fdo::Result<()> {
+        self.store
+            .put(INDEX_ITEM, serde_json::to_vec(index).map_err(failed)?)
+            .map_err(failed)
+    }
+
+    fn create_or_replace(
+        &self,
+        label: String,
+        attributes: HashMap<String, String>,
+        value: Vec<u8>,
+        content_type: String,
+        replace: bool,
+    ) -> fdo::Result<(IndexItem, bool)> {
+        let mut index = self.index.lock().map_err(poisoned)?;
+        let existing = index
+            .items
+            .iter()
+            .position(|item| item.attributes == attributes);
+        let id = match (existing, replace) {
+            (Some(position), true) => index.items[position].id.clone(),
+            (Some(_), false) => {
+                return Err(fdo::Error::Failed(
+                    "an item with these attributes already exists".to_owned(),
+                ));
+            }
+            (None, _) => random_id().map_err(failed)?,
+        };
+        let now = unix_time();
+        let item = IndexItem {
+            id: id.clone(),
+            label,
+            attributes,
+            content_type,
+            created: existing.map_or(now, |position| index.items[position].created),
+            modified: now,
+        };
+        self.store.put(secret_item(&id), value).map_err(failed)?;
+        let created = existing.is_none();
+        if let Some(position) = existing {
+            index.items[position] = item.clone();
+        } else {
+            index.items.push(item.clone());
+        }
+        self.save_index(&index)?;
+        Ok((item, created))
+    }
+
+    fn set_secret(&self, id: &str, value: Vec<u8>, content_type: String) -> fdo::Result<()> {
+        self.store.put(secret_item(id), value).map_err(failed)?;
+        let mut index = self.index.lock().map_err(poisoned)?;
+        let item = index
+            .items
+            .iter_mut()
+            .find(|item| item.id == id)
+            .ok_or_else(|| no_item(id))?;
+        item.content_type = content_type;
+        item.modified = unix_time();
+        self.save_index(&index)
+    }
+
+    fn delete_item(&self, id: &str) -> fdo::Result<()> {
+        self.store.delete(secret_item(id)).map_err(failed)?;
+        let mut index = self.index.lock().map_err(poisoned)?;
+        let Some(position) = index.items.iter().position(|item| item.id == id) else {
+            return Err(no_item(id));
+        };
+        index.items.remove(position);
+        self.save_index(&index)
+    }
+
+    fn open_session(&self, path: String, owner: String) -> fdo::Result<()> {
+        self.sessions.lock().map_err(poisoned)?.insert(path, owner);
+        Ok(())
+    }
+
+    fn check_session(&self, path: &OwnedObjectPath, owner: &str) -> fdo::Result<()> {
+        match self.sessions.lock().map_err(poisoned)?.get(path.as_str()) {
+            Some(expected) if expected == owner => Ok(()),
+            _ => Err(fdo::Error::Failed(
+                "invalid Secret Service session".to_owned(),
+            )),
+        }
+    }
+}
+
+struct Service {
+    agent: Arc<Agent>,
+}
+struct Collection {
+    agent: Arc<Agent>,
+}
+struct Item {
+    agent: Arc<Agent>,
+    id: String,
+}
+struct Session {
+    agent: Arc<Agent>,
+    owner: String,
+    path: String,
+}
+
+#[interface(name = "org.freedesktop.Secret.Service")]
+impl Service {
+    #[zbus(out_args("output", "result"))]
+    async fn open_session(
+        &self,
+        algorithm: String,
+        _input: OwnedValue,
+        #[zbus(header)] header: zbus::message::Header<'_>,
+        #[zbus(object_server)] server: &ObjectServer,
+    ) -> fdo::Result<(OwnedValue, OwnedObjectPath)> {
+        if algorithm != "plain" {
+            return Err(fdo::Error::Failed(
+                "Factorseal currently supports the plain Secret Service session algorithm"
+                    .to_owned(),
+            ));
+        }
+        let owner = sender(&header)?;
+        let path = format!("{SESSION_PREFIX}{}", random_id().map_err(failed)?);
+        self.agent.open_session(path.clone(), owner.clone())?;
+        let object_path = object_path(&path)?;
+        server
+            .at(
+                path.clone(),
+                Session {
+                    agent: Arc::clone(&self.agent),
+                    owner,
+                    path,
+                },
+            )
+            .await
+            .map_err(failed)?;
+        let output =
+            OwnedValue::try_from(zbus::zvariant::Value::from(String::new())).map_err(failed)?;
+        Ok((output, object_path))
+    }
+
+    #[zbus(out_args("unlocked", "locked"))]
+    fn search_items(
+        &self,
+        attributes: HashMap<String, String>,
+    ) -> fdo::Result<(Vec<OwnedObjectPath>, Vec<OwnedObjectPath>)> {
+        let paths = self
+            .agent
+            .all_items()?
+            .into_iter()
+            .filter(|item| {
+                attributes
+                    .iter()
+                    .all(|(key, value)| item.attributes.get(key) == Some(value))
+            })
+            .map(|item| item_path(&item.id))
+            .collect::<fdo::Result<Vec<_>>>()?;
+        Ok((paths, Vec::new()))
+    }
+
+    #[zbus(out_args("unlocked", "prompt"))]
+    fn unlock(
+        &self,
+        objects: Vec<OwnedObjectPath>,
+    ) -> fdo::Result<(Vec<OwnedObjectPath>, OwnedObjectPath)> {
+        Ok((objects, root_path()?))
+    }
+
+    #[zbus(out_args("locked", "prompt"))]
+    fn lock(
+        &self,
+        objects: Vec<OwnedObjectPath>,
+    ) -> fdo::Result<(Vec<OwnedObjectPath>, OwnedObjectPath)> {
+        self.agent.store.service.seal().map_err(failed)?;
+        Ok((objects, root_path()?))
+    }
+
+    #[zbus(out_args("secrets",))]
+    fn get_secrets(
+        &self,
+        items: Vec<OwnedObjectPath>,
+        session: OwnedObjectPath,
+        #[zbus(header)] header: zbus::message::Header<'_>,
+    ) -> fdo::Result<HashMap<OwnedObjectPath, Secret>> {
+        self.agent.check_session(&session, &sender(&header)?)?;
+        let mut result = HashMap::new();
+        for path in items {
+            let id = item_id(path.as_str())?;
+            let item = self.agent.item(id)?;
+            let value = self
+                .agent
+                .store
+                .get(secret_item(id))
+                .map_err(failed)?
+                .ok_or_else(|| no_item(id))?;
+            result.insert(
+                path,
+                (session.clone(), Vec::new(), value, item.content_type),
+            );
+        }
+        Ok(result)
+    }
+
+    #[zbus(out_args("collection",))]
+    fn read_alias(&self, name: String) -> fdo::Result<OwnedObjectPath> {
+        if name == "default" {
+            object_path(DEFAULT_ALIAS_PATH)
+        } else {
+            root_path()
+        }
+    }
+
+    #[zbus(property)]
+    fn collections(&self) -> fdo::Result<Vec<OwnedObjectPath>> {
+        Ok(vec![object_path(COLLECTION_PATH)?])
+    }
+}
+
+#[interface(name = "org.freedesktop.Secret.Collection")]
+impl Collection {
+    #[zbus(out_args("results",))]
+    fn search_items(
+        &self,
+        attributes: HashMap<String, String>,
+    ) -> fdo::Result<Vec<OwnedObjectPath>> {
+        self.agent
+            .all_items()?
+            .into_iter()
+            .filter(|item| {
+                attributes
+                    .iter()
+                    .all(|(key, value)| item.attributes.get(key) == Some(value))
+            })
+            .map(|item| item_path(&item.id))
+            .collect()
+    }
+
+    #[zbus(out_args("item", "prompt"))]
+    async fn create_item(
+        &self,
+        properties: Properties,
+        secret: Secret,
+        replace: bool,
+        #[zbus(header)] header: zbus::message::Header<'_>,
+        #[zbus(object_server)] server: &ObjectServer,
+    ) -> fdo::Result<(OwnedObjectPath, OwnedObjectPath)> {
+        self.agent.check_session(&secret.0, &sender(&header)?)?;
+        if !secret.1.is_empty() {
+            return Err(fdo::Error::Failed(
+                "plain sessions do not use parameters".to_owned(),
+            ));
+        }
+        let label = property_string(&properties, "org.freedesktop.Secret.Item.Label")?;
+        let attributes = property_map(&properties, "org.freedesktop.Secret.Item.Attributes")?;
+        let (item, created) = self
+            .agent
+            .create_or_replace(label, attributes, secret.2, secret.3, replace)?;
+        let path = item_path(&item.id)?;
+        if created {
+            server
+                .at(
+                    path.clone(),
+                    Item {
+                        agent: Arc::clone(&self.agent),
+                        id: item.id,
+                    },
+                )
+                .await
+                .map_err(failed)?;
+        }
+        Ok((path, root_path()?))
+    }
+
+    #[zbus(property)]
+    fn items(&self) -> fdo::Result<Vec<OwnedObjectPath>> {
+        self.agent
+            .all_items()?
+            .into_iter()
+            .map(|item| item_path(&item.id))
+            .collect()
+    }
+    #[zbus(property)]
+    fn label(&self) -> String {
+        "Factorseal".to_owned()
+    }
+    #[zbus(property)]
+    fn locked(&self) -> bool {
+        false
+    }
+}
+
+#[interface(name = "org.freedesktop.Secret.Item")]
+impl Item {
+    #[zbus(out_args("secret",))]
+    fn get_secret(
+        &self,
+        session: OwnedObjectPath,
+        #[zbus(header)] header: zbus::message::Header<'_>,
+    ) -> fdo::Result<Secret> {
+        self.agent.check_session(&session, &sender(&header)?)?;
+        let item = self.agent.item(&self.id)?;
+        let value = self
+            .agent
+            .store
+            .get(secret_item(&self.id))
+            .map_err(failed)?
+            .ok_or_else(|| no_item(&self.id))?;
+        Ok((session, Vec::new(), value, item.content_type))
+    }
+
+    fn set_secret(
+        &self,
+        secret: Secret,
+        #[zbus(header)] header: zbus::message::Header<'_>,
+    ) -> fdo::Result<()> {
+        self.agent.check_session(&secret.0, &sender(&header)?)?;
+        if !secret.1.is_empty() {
+            return Err(fdo::Error::Failed(
+                "plain sessions do not use parameters".to_owned(),
+            ));
+        }
+        self.agent.set_secret(&self.id, secret.2, secret.3)
+    }
+
+    #[zbus(out_args("prompt",))]
+    async fn delete(
+        &self,
+        #[zbus(object_server)] server: &ObjectServer,
+    ) -> fdo::Result<OwnedObjectPath> {
+        self.agent.delete_item(&self.id)?;
+        server
+            .remove::<Item, _>(item_path(&self.id)?)
+            .await
+            .map_err(failed)?;
+        root_path()
+    }
+
+    #[zbus(property)]
+    fn label(&self) -> fdo::Result<String> {
+        Ok(self.agent.item(&self.id)?.label)
+    }
+    #[zbus(property)]
+    fn attributes(&self) -> fdo::Result<HashMap<String, String>> {
+        Ok(self.agent.item(&self.id)?.attributes)
+    }
+    #[zbus(property)]
+    fn locked(&self) -> bool {
+        false
+    }
+    #[zbus(property)]
+    fn created(&self) -> fdo::Result<u64> {
+        Ok(self.agent.item(&self.id)?.created)
+    }
+    #[zbus(property)]
+    fn modified(&self) -> fdo::Result<u64> {
+        Ok(self.agent.item(&self.id)?.modified)
+    }
+}
+
+#[interface(name = "org.freedesktop.Secret.Session")]
+impl Session {
+    fn close(&self, #[zbus(header)] header: zbus::message::Header<'_>) -> fdo::Result<()> {
+        if sender(&header)? != self.owner {
+            return Err(fdo::Error::Failed(
+                "Secret Service session belongs to another client".to_owned(),
+            ));
+        }
+        self.agent
+            .sessions
+            .lock()
+            .map_err(poisoned)?
+            .remove(&self.path);
+        Ok(())
+    }
+}
+
+fn sender(header: &zbus::message::Header<'_>) -> fdo::Result<String> {
+    header
+        .sender()
+        .map(ToString::to_string)
+        .ok_or_else(|| fdo::Error::Failed("D-Bus caller has no unique name".to_owned()))
+}
+fn object_path(value: &str) -> fdo::Result<OwnedObjectPath> {
+    OwnedObjectPath::try_from(value).map_err(failed)
+}
+fn root_path() -> fdo::Result<OwnedObjectPath> {
+    object_path("/")
+}
+fn item_path(id: &str) -> fdo::Result<OwnedObjectPath> {
+    object_path(&format!("{ITEM_PREFIX}{id}"))
+}
+fn item_id(path: &str) -> fdo::Result<&str> {
+    path.strip_prefix(ITEM_PREFIX)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| fdo::Error::Failed("unknown Secret Service item".to_owned()))
+}
+fn secret_item(id: &str) -> String {
+    format!("item/{id}")
+}
+fn random_id() -> VaultResult<String> {
+    let mut bytes = [0_u8; 16];
+    getrandom::fill(&mut bytes)?;
+    Ok(hex::encode(bytes))
+}
+fn unix_time() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+fn dbus_error(error: zbus::Error) -> VaultError {
+    VaultError::Protocol(format!("Secret Service D-Bus error: {error}"))
+}
+fn failed(error: impl std::fmt::Display) -> fdo::Error {
+    fdo::Error::Failed(error.to_string())
+}
+fn poisoned<T>(_: std::sync::PoisonError<T>) -> fdo::Error {
+    fdo::Error::Failed("Secret Service state lock was poisoned".to_owned())
+}
+fn no_item(id: &str) -> fdo::Error {
+    fdo::Error::Failed(format!("no Secret Service item {id}"))
+}
+fn property_string(properties: &Properties, key: &str) -> fdo::Result<String> {
+    let value = properties
+        .get(key)
+        .ok_or_else(|| fdo::Error::Failed(format!("missing {key}")))?;
+    String::try_from(value.try_clone().map_err(failed)?)
+        .map_err(|_| fdo::Error::Failed(format!("invalid {key}")))
+}
+
+fn property_map(properties: &Properties, key: &str) -> fdo::Result<HashMap<String, String>> {
+    let value = properties
+        .get(key)
+        .ok_or_else(|| fdo::Error::Failed(format!("missing {key}")))?;
+    HashMap::<String, String>::try_from(value.try_clone().map_err(failed)?)
+        .map_err(|_| fdo::Error::Failed(format!("invalid {key}")))
+}

--- a/src/vault/secret_service.rs
+++ b/src/vault/secret_service.rs
@@ -12,6 +12,7 @@ use std::sync::{
 };
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use secret_service_protocol::{Session as ProtocolSession, SessionOutput};
 use serde::{Deserialize, Serialize};
 use zbus::object_server::ObjectServer;
 use zbus::zvariant::{OwnedObjectPath, OwnedValue};
@@ -202,7 +203,7 @@ struct IndexItem {
 struct Agent {
     store: Store,
     index: Mutex<Index>,
-    sessions: Mutex<HashMap<String, String>>,
+    sessions: Mutex<HashMap<String, SessionState>>,
 }
 
 impl Agent {
@@ -325,19 +326,60 @@ impl Agent {
         self.save_index(&index)
     }
 
-    fn open_session(&self, path: String, owner: String) -> fdo::Result<()> {
-        self.sessions.lock().map_err(poisoned)?.insert(path, owner);
+    fn open_session(
+        &self,
+        path: String,
+        owner: String,
+        session: ProtocolSession,
+    ) -> fdo::Result<()> {
+        self.sessions
+            .lock()
+            .map_err(poisoned)?
+            .insert(path, SessionState { owner, session });
         Ok(())
     }
 
-    fn check_session(&self, path: &OwnedObjectPath, owner: &str) -> fdo::Result<()> {
+    fn session(&self, path: &OwnedObjectPath, owner: &str) -> fdo::Result<ProtocolSession> {
         match self.sessions.lock().map_err(poisoned)?.get(path.as_str()) {
-            Some(expected) if expected == owner => Ok(()),
+            Some(session) if session.owner == owner => Ok(session.session.clone()),
             _ => Err(fdo::Error::Failed(
                 "invalid Secret Service session".to_owned(),
             )),
         }
     }
+
+    fn decrypt_secret(&self, secret: Secret, owner: &str) -> fdo::Result<(Vec<u8>, String)> {
+        let value = self
+            .session(&secret.0, owner)?
+            .decrypt(&secret.1, &secret.2)
+            .map_err(failed)?;
+        Ok((value.to_vec(), secret.3))
+    }
+
+    fn encrypt_secret(
+        &self,
+        session: OwnedObjectPath,
+        owner: &str,
+        value: Vec<u8>,
+        content_type: String,
+    ) -> fdo::Result<Secret> {
+        let value = self
+            .session(&session, owner)?
+            .encrypt(&value)
+            .map_err(failed)?;
+        Ok((
+            session,
+            value.parameters,
+            value.value.to_vec(),
+            content_type,
+        ))
+    }
+}
+
+#[derive(Clone)]
+struct SessionState {
+    owner: String,
+    session: ProtocolSession,
 }
 
 struct Service {
@@ -362,19 +404,16 @@ impl Service {
     async fn open_session(
         &self,
         algorithm: String,
-        _input: OwnedValue,
+        input: OwnedValue,
         #[zbus(header)] header: zbus::message::Header<'_>,
         #[zbus(object_server)] server: &ObjectServer,
     ) -> fdo::Result<(OwnedValue, OwnedObjectPath)> {
-        if algorithm != "plain" {
-            return Err(fdo::Error::Failed(
-                "Factorseal currently supports the plain Secret Service session algorithm"
-                    .to_owned(),
-            ));
-        }
+        let input = session_input(&algorithm, input)?;
+        let (session, output) = ProtocolSession::open(&algorithm, &input).map_err(failed)?;
         let owner = sender(&header)?;
         let path = format!("{SESSION_PREFIX}{}", random_id().map_err(failed)?);
-        self.agent.open_session(path.clone(), owner.clone())?;
+        self.agent
+            .open_session(path.clone(), owner.clone(), session)?;
         let object_path = object_path(&path)?;
         server
             .at(
@@ -387,9 +426,7 @@ impl Service {
             )
             .await
             .map_err(failed)?;
-        let output =
-            OwnedValue::try_from(zbus::zvariant::Value::from(String::new())).map_err(failed)?;
-        Ok((output, object_path))
+        Ok((session_output(output)?, object_path))
     }
 
     #[zbus(out_args("unlocked", "locked"))]
@@ -435,7 +472,7 @@ impl Service {
         session: OwnedObjectPath,
         #[zbus(header)] header: zbus::message::Header<'_>,
     ) -> fdo::Result<HashMap<OwnedObjectPath, Secret>> {
-        self.agent.check_session(&session, &sender(&header)?)?;
+        let owner = sender(&header)?;
         let mut result = HashMap::new();
         for path in items {
             let id = item_id(path.as_str())?;
@@ -448,7 +485,8 @@ impl Service {
                 .ok_or_else(|| no_item(id))?;
             result.insert(
                 path,
-                (session.clone(), Vec::new(), value, item.content_type),
+                self.agent
+                    .encrypt_secret(session.clone(), &owner, value, item.content_type)?,
             );
         }
         Ok(result)
@@ -497,17 +535,12 @@ impl Collection {
         #[zbus(header)] header: zbus::message::Header<'_>,
         #[zbus(object_server)] server: &ObjectServer,
     ) -> fdo::Result<(OwnedObjectPath, OwnedObjectPath)> {
-        self.agent.check_session(&secret.0, &sender(&header)?)?;
-        if !secret.1.is_empty() {
-            return Err(fdo::Error::Failed(
-                "plain sessions do not use parameters".to_owned(),
-            ));
-        }
+        let (value, content_type) = self.agent.decrypt_secret(secret, &sender(&header)?)?;
         let label = property_string(&properties, "org.freedesktop.Secret.Item.Label")?;
         let attributes = property_map(&properties, "org.freedesktop.Secret.Item.Attributes")?;
-        let (item, created) = self
-            .agent
-            .create_or_replace(label, attributes, secret.2, secret.3, replace)?;
+        let (item, created) =
+            self.agent
+                .create_or_replace(label, attributes, value, content_type, replace)?;
         let path = item_path(&item.id)?;
         if created {
             server
@@ -550,7 +583,7 @@ impl Item {
         session: OwnedObjectPath,
         #[zbus(header)] header: zbus::message::Header<'_>,
     ) -> fdo::Result<Secret> {
-        self.agent.check_session(&session, &sender(&header)?)?;
+        let owner = sender(&header)?;
         let item = self.agent.item(&self.id)?;
         let value = self
             .agent
@@ -558,7 +591,8 @@ impl Item {
             .get(secret_item(&self.id))
             .map_err(failed)?
             .ok_or_else(|| no_item(&self.id))?;
-        Ok((session, Vec::new(), value, item.content_type))
+        self.agent
+            .encrypt_secret(session, &owner, value, item.content_type)
     }
 
     fn set_secret(
@@ -566,13 +600,8 @@ impl Item {
         secret: Secret,
         #[zbus(header)] header: zbus::message::Header<'_>,
     ) -> fdo::Result<()> {
-        self.agent.check_session(&secret.0, &sender(&header)?)?;
-        if !secret.1.is_empty() {
-            return Err(fdo::Error::Failed(
-                "plain sessions do not use parameters".to_owned(),
-            ));
-        }
-        self.agent.set_secret(&self.id, secret.2, secret.3)
+        let (value, content_type) = self.agent.decrypt_secret(secret, &sender(&header)?)?;
+        self.agent.set_secret(&self.id, value, content_type)
     }
 
     #[zbus(out_args("prompt",))]
@@ -624,6 +653,35 @@ impl Session {
             .map_err(poisoned)?
             .remove(&self.path);
         Ok(())
+    }
+}
+
+fn session_input(algorithm: &str, input: OwnedValue) -> fdo::Result<Vec<u8>> {
+    if algorithm == secret_service_protocol::ALGORITHM_PLAIN {
+        let plain = String::try_from(input).map_err(|_| {
+            fdo::Error::Failed("invalid plain Secret Service session input".to_owned())
+        })?;
+        if plain.is_empty() {
+            Ok(Vec::new())
+        } else {
+            Err(fdo::Error::Failed(
+                "plain Secret Service session input must be empty".to_owned(),
+            ))
+        }
+    } else {
+        Vec::<u8>::try_from(input)
+            .map_err(|_| fdo::Error::Failed("invalid Secret Service DH public key".to_owned()))
+    }
+}
+
+fn session_output(output: SessionOutput) -> fdo::Result<OwnedValue> {
+    match output {
+        SessionOutput::Plain => {
+            OwnedValue::try_from(zbus::zvariant::Value::from(String::new())).map_err(failed)
+        }
+        SessionOutput::DhPublicKey(value) => {
+            OwnedValue::try_from(zbus::zvariant::Value::from(value)).map_err(failed)
+        }
     }
 }
 


### PR DESCRIPTION
Summary:
- expose org.freedesktop.secrets from the live, unsealed Factorseal user service using zbus
- keep Secret Service data in a dedicated encrypted vault namespace
- add a NixOS TPM VM assertion for the D-Bus interface and physical-host acceptance runners

Validation:
- devenv shell cargo check --all-features
- nix build .#packages.x86_64-linux.factorseal --no-link

The NixOS VM test is included but still needs a full run in CI or local QEMU.