### PR TITLE
Fix signing on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Lint packaged shell scripts
         run: devenv shell -- shellcheck packaging/build-unix.sh packaging/linux/factorseal-start
       - name: Lint packaged POSIX helpers
-        run: devenv shell -- shellcheck -s sh packaging/macos/factorseal-askpass
+        run: devenv shell -- shellcheck -s sh packaging/macos/factorseal-askpass packaging/macos/prepare-app.sh packaging/macos/sign-app.sh
       - name: Lint opt-in native acceptance runners
         run: devenv shell -- shellcheck acceptance/linux.sh acceptance/macos.sh
       - name: Evaluate the physical Linux acceptance app
@@ -80,17 +80,35 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Run tests
         run: cargo test --all-targets --all-features
-      - name: Validate macOS packaging inputs and signing gate
+      - name: Build and inspect locally signed macOS package
         run: |
           plutil -lint packaging/macos/Info.plist packaging/macos/dev.factorseal.plist packaging/macos/Factorseal.entitlements.in
-          if packaging_output=$(env \
+          env \
             -u FACTORSEAL_MACOS_SIGNING_IDENTITY \
             -u FACTORSEAL_MACOS_PROVISIONING_PROFILE \
-            packaging/build-unix.sh macos 2>&1); then
-            echo "macOS packaging unexpectedly succeeded without signing credentials" >&2
+            packaging/build-unix.sh macos
+
+          archive=$(find dist -name 'factorseal-*-macos-*.tar.gz' -print -quit)
+          unpacked=$(mktemp -d)
+          tar -xzf "$archive" -C "$unpacked"
+          app=$(find "$unpacked" -name Factorseal.app -type d -print -quit)
+
+          codesign --verify --deep --strict "$app"
+          codesign -dvv "$app" 2>&1 | grep '^Signature=adhoc$'
+          test ! -e "$app/Contents/embedded.provisionprofile"
+          entitlements=$(mktemp)
+          codesign -d --entitlements - --xml "$app" >"$entitlements" 2>/dev/null || true
+          if grep -Eq 'application-identifier|keychain-access-groups' "$entitlements"; then
+            echo "local package unexpectedly contains Team-only Keychain entitlements" >&2
             exit 1
           fi
-          printf '%s\n' "$packaging_output" | grep 'macOS packaging requires FACTORSEAL_MACOS_SIGNING_IDENTITY and FACTORSEAL_MACOS_PROVISIONING_PROFILE'
+          while IFS= read -r candidate; do
+            file -b "$candidate" | grep -q 'Mach-O' || continue
+            if otool -l "$candidate" | grep -F '/nix/store/'; then
+              echo "Nix store reference remains in $candidate" >&2
+              exit 1
+            fi
+          done < <(find "$app/Contents" -type f -print)
 
   windows:
     name: Windows

--- a/crates/hardwareseal/src/apple.rs
+++ b/crates/hardwareseal/src/apple.rs
@@ -85,7 +85,7 @@ pub(super) fn delete(
     // Every generation sealed under this label shares one account prefix, so
     // deleting the protector removes the superseded items too.
     let prefix = account_prefix(label_hash, policy);
-    for account in stored_accounts()? {
+    for account in stored_accounts(policy)? {
         if account.starts_with(&prefix) {
             delete_if_present(&account)?;
         }
@@ -102,17 +102,19 @@ fn delete_if_present(account: &str) -> Result<(), Error> {
 }
 
 /// List the accounts of every hardwareseal item in the Data Protection Keychain.
-fn stored_accounts() -> Result<Vec<String>, Error> {
+fn stored_accounts(policy: AccessPolicy) -> Result<Vec<String>, Error> {
     let mut search = ItemSearchOptions::new();
     search
         .class(ItemClass::generic_password())
         .service(SERVICE)
         .load_attributes(true)
         .limit(Limit::All)
-        // Listing must never raise a biometric prompt: deleting a protector is
-        // a management operation, not an unseal.
-        .skip_authenticated_items(true)
         .ignore_legacy_keychains();
+    if policy == AccessPolicy::None {
+        // A non-biometric delete must not prompt because another protector uses
+        // biometric items under the same service.
+        search.skip_authenticated_items(true);
+    }
     let results = match search.search() {
         Ok(results) => results,
         Err(error) if error.code() == ERR_SEC_ITEM_NOT_FOUND => return Ok(Vec::new()),

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -11,10 +11,8 @@ artifact is ready to release:
 
 - `build-unix.sh linux` creates a tarball with the binaries, systemd user unit,
   interactive session-agent helper, and one-command physical acceptance runner;
-- `build-unix.sh macos` requires `FACTORSEAL_MACOS_SIGNING_IDENTITY` and
-  `FACTORSEAL_MACOS_PROVISIONING_PROFILE`, then creates a tarball containing a
-  signed app plus an unsigned `.pkg`. The tarball also carries the one-command
-  runner, askpass helper, and LaunchAgent property list;
+- `build-unix.sh macos` creates a tarball and an unsigned `.pkg`. The app is
+  signed locally unless an Apple identity and profile are supplied;
 - `build-windows.ps1` creates a ZIP containing the executables, the askpass
   helper, Scheduled Task installer, and one-command physical acceptance runner;
 - `build-windows-msix.ps1` creates the CLI-oriented MSIX submitted to the
@@ -112,22 +110,18 @@ terminal and run `factorseal --version`, `factorseal init`, and then
 `factorseal agent`. Automatic login startup is deferred until the interim
 PowerShell password dialog has been replaced by a native prompt.
 
-The macOS profile must authorize the explicit `dev.factorseal` App ID and its
-default keychain access group. This is not optional for native acceptance:
-Apple derives Data Protection Keychain access groups from restricted signing
-entitlements authorized by the embedded profile. For example:
+For physical macOS testing, provide an Apple Development identity and a
+matching profile for `dev.factorseal`:
 
 ```console
-FACTORSEAL_MACOS_SIGNING_IDENTITY='Developer ID Application: Example (TEAMID)' \
+FACTORSEAL_MACOS_SIGNING_IDENTITY='Apple Development: You (TEAMID)' \
 FACTORSEAL_MACOS_PROVISIONING_PROFILE=/private/path/Factorseal.provisionprofile \
-  packaging/build-unix.sh macos
+devenv shell -- packaging/build-unix.sh macos
 ```
 
-The builder decodes the profile, derives the team identifier, embeds the
-profile, signs `Factorseal.app` with hardened runtime and the matching
-application/keychain entitlements, and verifies the resulting app signature.
-It deliberately does not claim that the `.pkg` is signed or that either output
-is notarized.
+Set both variables or neither. Without them, the app cannot use Factorseal's
+protected Keychain storage or pass physical acceptance. Release distribution
+also requires signing the `.pkg` and notarization.
 
 ## Obtaining a password factor
 

--- a/packaging/build-unix.sh
+++ b/packaging/build-unix.sh
@@ -23,14 +23,22 @@ provisioning_profile=
 if [ "$platform" = macos ]; then
     signing_identity=${FACTORSEAL_MACOS_SIGNING_IDENTITY:-}
     provisioning_profile=${FACTORSEAL_MACOS_PROVISIONING_PROFILE:-}
-    [ -n "$signing_identity" ] && [ -n "$provisioning_profile" ] || {
-        echo "macOS packaging requires FACTORSEAL_MACOS_SIGNING_IDENTITY and FACTORSEAL_MACOS_PROVISIONING_PROFILE" >&2
+    if [ -n "$signing_identity" ] && [ -z "$provisioning_profile" ]; then
+        echo "FACTORSEAL_MACOS_PROVISIONING_PROFILE is required when FACTORSEAL_MACOS_SIGNING_IDENTITY is set" >&2
         exit 2
-    }
-    [ -f "$provisioning_profile" ] || {
-        echo "macOS provisioning profile does not exist: $provisioning_profile" >&2
+    fi
+    if [ -n "$provisioning_profile" ] && [ -z "$signing_identity" ]; then
+        echo "FACTORSEAL_MACOS_SIGNING_IDENTITY is required when FACTORSEAL_MACOS_PROVISIONING_PROFILE is set" >&2
         exit 2
-    }
+    fi
+    if [ -n "$provisioning_profile" ]; then
+        [ -f "$provisioning_profile" ] || {
+            echo "macOS provisioning profile does not exist: $provisioning_profile" >&2
+            exit 2
+        }
+    else
+        signing_identity=-
+    fi
 fi
 
 # Where README.md tells a Linux user to install the Factorseal binary. The systemd
@@ -41,6 +49,16 @@ version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1)
 archive="factorseal-${version}-${platform}-$(uname -m)"
 stage=$(mktemp -d)
 trap 'rm -rf "$stage"' EXIT HUP INT TERM
+
+if [ "$platform" = macos ]; then
+    # The SDK controls available declarations; the deployment target separately
+    # controls the oldest runnable macOS. Build cleanly so stale metadata cannot
+    # survive a target change.
+    macos_deployment_target=11.0
+    MACOSX_DEPLOYMENT_TARGET=$macos_deployment_target
+    CARGO_TARGET_DIR="$stage/cargo-target"
+    export MACOSX_DEPLOYMENT_TARGET CARGO_TARGET_DIR
+fi
 
 cargo build --locked --release --no-default-features \
     --features vault,cli,hardware \
@@ -73,34 +91,24 @@ if [ "$platform" = linux ]; then
         "$stage/$archive/bin/factorseal-start"
 else
     app="$stage/$archive/Factorseal.app/Contents"
-    mkdir -p "$app/MacOS" "$stage/$archive/Library/LaunchAgents"
+    mkdir -p "$app/MacOS" "$app/Resources" "$stage/$archive/Library/LaunchAgents"
     cp "$target_dir/release/factorseal" "$app/MacOS/"
-    cp packaging/macos/factorseal-askpass "$app/MacOS/"
+    cp packaging/macos/factorseal-askpass "$app/Resources/"
     sed "s/@VERSION@/$version/g" packaging/macos/Info.plist > "$app/Info.plist"
     cp packaging/macos/dev.factorseal.plist "$stage/$archive/Library/LaunchAgents/"
-    chmod 0755 "$app/MacOS/factorseal" "$app/MacOS/factorseal-askpass"
+    chmod 0755 "$app/MacOS/factorseal" "$app/Resources/factorseal-askpass"
 
-    # The Data Protection Keychain derives its access groups from restricted
-    # code-signing entitlements. A profile is therefore required even though
-    # Factorseal does not share items with another app.
-    profile_plist="$stage/provisioning-profile.plist"
-    security cms -D -i "$provisioning_profile" >"$profile_plist"
-    team_id=$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.developer.team-identifier' "$profile_plist")
-    profile_application_id=$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.application-identifier' "$profile_plist")
-    application_id="$team_id.dev.factorseal"
-    case $profile_application_id in
-        "$application_id"|"$team_id.*") ;;
-        *)
-            echo "provisioning profile authorizes $profile_application_id, not $application_id" >&2
-            exit 2
-            ;;
-    esac
-    entitlements="$stage/Factorseal.entitlements"
-    sed "s/@TEAM_ID@/$team_id/g" packaging/macos/Factorseal.entitlements.in >"$entitlements"
-    cp "$provisioning_profile" "$app/embedded.provisionprofile"
-    codesign --force --options runtime --timestamp \
-        --sign "$signing_identity" --entitlements "$entitlements" "${app%/Contents}"
-    codesign --verify --strict --verbose=2 "${app%/Contents}"
+    sh packaging/macos/prepare-app.sh \
+        "${app%/Contents}" \
+        "$macos_deployment_target"
+    if [ -n "$provisioning_profile" ]; then
+        sh packaging/macos/sign-app.sh \
+            "${app%/Contents}" \
+            "$signing_identity" \
+            "$provisioning_profile"
+    else
+        sh packaging/macos/sign-app.sh "${app%/Contents}" -
+    fi
 fi
 
 tar -C "$stage" -czf "$output_dir/$archive.tar.gz" "$archive"
@@ -113,7 +121,9 @@ echo "$output_dir/$archive-acceptance.sh"
 if [ "$platform" = macos ]; then
     package_root="$stage/package-root"
     mkdir -p "$package_root/Applications" "$package_root/Library/LaunchAgents"
-    cp -R "$stage/$archive/Factorseal.app" "$package_root/Applications/"
+    /usr/bin/ditto \
+        "$stage/$archive/Factorseal.app" \
+        "$package_root/Applications/Factorseal.app"
     cp packaging/macos/dev.factorseal.plist "$package_root/Library/LaunchAgents/"
     pkgbuild \
         --root "$package_root" \

--- a/packaging/macos/Factorseal.entitlements.in
+++ b/packaging/macos/Factorseal.entitlements.in
@@ -3,8 +3,12 @@
 <plist version="1.0">
 <dict>
   <key>com.apple.application-identifier</key>
-  <string>@TEAM_ID@.dev.factorseal</string>
+  <string>@APPLICATION_ID@</string>
   <key>com.apple.developer.team-identifier</key>
   <string>@TEAM_ID@</string>
+  <key>keychain-access-groups</key>
+  <array>
+    <string>@APPLICATION_ID@</string>
+  </array>
 </dict>
 </plist>

--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -9,6 +9,7 @@
   <key>CFBundleName</key><string>Factorseal</string>
   <key>CFBundlePackageType</key><string>APPL</string>
   <key>CFBundleShortVersionString</key><string>@VERSION@</string>
+  <key>CFBundleVersion</key><string>@VERSION@</string>
   <key>LSUIElement</key><true/>
   <key>NSHumanReadableCopyright</key><string>Copyright Factorseal contributors</string>
 </dict>

--- a/packaging/macos/dev.factorseal.plist
+++ b/packaging/macos/dev.factorseal.plist
@@ -7,7 +7,7 @@
   <array>
     <string>/Applications/Factorseal.app/Contents/MacOS/factorseal</string>
     <string>--askpass</string>
-    <string>/Applications/Factorseal.app/Contents/MacOS/factorseal-askpass</string>
+    <string>/Applications/Factorseal.app/Contents/Resources/factorseal-askpass</string>
     <string>agent</string>
   </array>
   <key>RunAtLoad</key><true/>

--- a/packaging/macos/prepare-app.sh
+++ b/packaging/macos/prepare-app.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -eu
+
+usage() {
+    echo "usage: $0 APP_BUNDLE DEPLOYMENT_TARGET" >&2
+    exit 2
+}
+
+[ "$#" -eq 2 ] || usage
+app=$1
+deployment_target=$2
+
+[ "$(uname -s)" = Darwin ] || {
+    echo "macOS app preparation must run on macOS" >&2
+    exit 2
+}
+[ -d "$app/Contents" ] || { echo "app bundle not found: $app" >&2; exit 2; }
+[ -f "$app/Contents/Info.plist" ] || { echo "Info.plist not found in $app" >&2; exit 2; }
+
+executable=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$app/Contents/Info.plist")
+main="$app/Contents/MacOS/$executable"
+[ -f "$main" ] || { echo "app executable not found: $main" >&2; exit 2; }
+
+# Nixpkgs links against its own libiconv, but that path does not exist on
+# another Mac. The SDK exposes the same library from macOS, so use that path
+# before signing.
+/usr/bin/find "$app/Contents" -type f -print | while IFS= read -r candidate; do
+    /usr/bin/file -b "$candidate" | /usr/bin/grep -q 'Mach-O' || continue
+    /usr/bin/otool -L "$candidate" | /usr/bin/awk 'NR > 1 { print $1 }' |
+        while IFS= read -r dependency; do
+            case $dependency in
+                /nix/store/*-libiconv-*/lib/libiconv.2.dylib)
+                    /usr/bin/install_name_tool -change \
+                        "$dependency" /usr/lib/libiconv.2.dylib "$candidate"
+                    ;;
+            esac
+        done
+done
+
+# Check every load command, not only LC_LOAD_DYLIB. This catches store-backed
+# rpaths and future native dependencies rather than silently shipping them.
+/usr/bin/find "$app/Contents" -type f -print | while IFS= read -r candidate; do
+    /usr/bin/file -b "$candidate" | /usr/bin/grep -q 'Mach-O' || continue
+    if /usr/bin/otool -l "$candidate" | /usr/bin/grep -F '/nix/store/' >/dev/null; then
+        echo "Nix store load command remains in $candidate:" >&2
+        /usr/bin/otool -l "$candidate" | /usr/bin/grep -F '/nix/store/' >&2
+        exit 1
+    fi
+done
+
+/usr/bin/find "$app/Contents" -type f -print | while IFS= read -r candidate; do
+    /usr/bin/file -b "$candidate" | /usr/bin/grep -q 'Mach-O' || continue
+
+    actual_targets=$(/usr/bin/otool -l "$candidate" |
+        /usr/bin/awk '$1 == "minos" { print $2 }' | /usr/bin/sort -u)
+    [ "$actual_targets" = "$deployment_target" ] || {
+        echo "expected macOS deployment target $deployment_target in $candidate, found: $actual_targets" >&2
+        exit 1
+    }
+done
+
+echo "Prepared portable app for macOS $deployment_target"

--- a/packaging/macos/sign-app.sh
+++ b/packaging/macos/sign-app.sh
@@ -1,0 +1,215 @@
+#!/bin/sh
+set -eu
+umask 077
+
+usage() {
+    echo "usage: $0 APP_BUNDLE SIGNING_IDENTITY [PROVISIONING_PROFILE]" >&2
+    exit 2
+}
+
+case $# in 2|3) ;; *) usage ;; esac
+app=$1
+signing_identity=$2
+profile=${3:-}
+
+[ "$(uname -s)" = Darwin ] || {
+    echo "macOS app signing must run on macOS" >&2
+    exit 2
+}
+[ -d "$app/Contents" ] || { echo "app bundle not found: $app" >&2; exit 2; }
+[ -f "$app/Contents/Info.plist" ] || { echo "Info.plist not found in $app" >&2; exit 2; }
+[ -n "$signing_identity" ] || { echo "signing identity must not be empty" >&2; exit 2; }
+[ -n "$profile" ] || [ "$signing_identity" = - ] || {
+    echo "a signing identity requires a provisioning profile" >&2
+    exit 2
+}
+[ -z "$profile" ] || [ "$signing_identity" != - ] || {
+    echo "a provisioning profile requires an Apple signing identity" >&2
+    exit 2
+}
+[ -z "$profile" ] || [ -f "$profile" ] || {
+    echo "provisioning profile not found: $profile" >&2
+    exit 2
+}
+
+script_dir=$(CDPATH='' cd -P "$(dirname "$0")" && pwd)
+scratch=$(mktemp -d "${TMPDIR:-/tmp}/factorseal-signing.XXXXXX")
+trap 'rm -rf "$scratch"' EXIT HUP INT TERM
+
+bundle_id=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app/Contents/Info.plist")
+case $bundle_id in
+    ''|*[!A-Za-z0-9.-]*) echo "invalid bundle identifier: $bundle_id" >&2; exit 2 ;;
+esac
+
+if [ -n "$profile" ]; then
+    profile_plist="$scratch/profile.plist"
+    /usr/bin/security cms -D -i "$profile" >"$profile_plist"
+    team_id=$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$profile_plist")
+    app_id_prefix=$(/usr/libexec/PlistBuddy -c 'Print :ApplicationIdentifierPrefix:0' "$profile_plist")
+    profile_app_id=$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.application-identifier' "$profile_plist")
+    application_id="$app_id_prefix.$bundle_id"
+
+    case $team_id in
+        ''|*[!A-Za-z0-9]*) echo "invalid team identifier in provisioning profile" >&2; exit 2 ;;
+    esac
+    case $app_id_prefix in
+        ''|*[!A-Za-z0-9]*) echo "invalid app identifier prefix in provisioning profile" >&2; exit 2 ;;
+    esac
+    if [ "$profile_app_id" != "$application_id" ] && [ "$profile_app_id" != "$app_id_prefix.*" ]; then
+        echo "provisioning profile authorizes $profile_app_id, not $application_id" >&2
+        exit 2
+    fi
+
+    profile_authorizes_group=false
+    group_index=0
+    while profile_group=$(/usr/bin/plutil -extract \
+        "Entitlements.keychain-access-groups.$group_index" \
+        raw -o - "$profile_plist" 2>/dev/null); do
+        if [ "$profile_group" = "$application_id" ] || \
+            [ "$profile_group" = "$app_id_prefix.*" ]; then
+            profile_authorizes_group=true
+        fi
+        group_index=$((group_index + 1))
+    done
+    [ "$profile_authorizes_group" = true ] || {
+        echo "provisioning profile does not authorize keychain access group $application_id" >&2
+        exit 2
+    }
+
+    identities=$(/usr/bin/security find-identity -v -p codesigning)
+    identity_matches=$(printf '%s\n' "$identities" | /usr/bin/awk \
+        -v requested="$signing_identity" '
+        /^[[:space:]]*[0-9]+\)[[:space:]]+[0-9A-Fa-f]{40}[[:space:]]+"/ {
+            hash = toupper($2)
+            name = $0
+            sub(/^[^"]*"/, "", name)
+            sub(/"[^"]*$/, "", name)
+            if (toupper(requested) == hash || requested == name)
+                print hash "\t" name
+        }')
+    match_count=$(printf '%s\n' "$identity_matches" | /usr/bin/awk 'NF { count++ } END { print count + 0 }')
+    case $match_count in
+        0)
+            echo "signing identity not found: $signing_identity" >&2
+            exit 2
+            ;;
+        1) ;;
+        *)
+            echo "more than one signing identity has that name; use its SHA-1 hash" >&2
+            exit 2
+            ;;
+    esac
+    identity_hash=$(printf '%s\n' "$identity_matches" | /usr/bin/awk -F '\t' 'NF { print $1 }')
+    identity_name=$(printf '%s\n' "$identity_matches" | /usr/bin/awk -F '\t' 'NF { print $2 }')
+
+    profile_authorizes_identity=false
+    certificate_index=0
+    while encoded_certificate=$(/usr/bin/plutil -extract \
+        "DeveloperCertificates.$certificate_index" \
+        raw -o - "$profile_plist" 2>/dev/null); do
+        certificate="$scratch/profile-certificate-$certificate_index.der"
+        printf '%s' "$encoded_certificate" | /usr/bin/base64 -D >"$certificate"
+        certificate_hash=$(/usr/bin/openssl x509 \
+            -inform DER -in "$certificate" -noout -fingerprint -sha1 |
+            /usr/bin/sed 's/^[^=]*=//; s/://g')
+        if [ "$certificate_hash" = "$identity_hash" ]; then
+            profile_authorizes_identity=true
+        fi
+        certificate_index=$((certificate_index + 1))
+    done
+    [ "$profile_authorizes_identity" = true ] || {
+        echo "provisioning profile does not authorize signing identity $identity_name ($identity_hash)" >&2
+        exit 2
+    }
+
+    entitlements="$scratch/Factorseal.entitlements"
+    /usr/bin/sed \
+        -e "s/@APPLICATION_ID@/$application_id/g" \
+        -e "s/@TEAM_ID@/$team_id/g" \
+        "$script_dir/Factorseal.entitlements.in" >"$entitlements"
+    cp "$profile" "$app/Contents/embedded.provisionprofile"
+else
+    # Do not carry a profile from an earlier Team-signed copy into a local build.
+    rm -f "$app/Contents/embedded.provisionprofile"
+fi
+
+case ${identity_name:-} in
+    'Developer ID Application:'*) timestamp=--timestamp ;;
+    *) timestamp=--timestamp=none ;;
+esac
+
+sign_nested() {
+    nested_code=$1
+    /usr/bin/codesign \
+        --force \
+        --sign "$signing_identity" \
+        --options runtime \
+        "$timestamp" \
+        "$nested_code"
+}
+
+main_name=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$app/Contents/Info.plist")
+main="$app/Contents/MacOS/$main_name"
+
+# Sign individual nested Mach-O files first. The main executable is signed as
+# part of the outer app so it receives the app's Keychain entitlements.
+/usr/bin/find "$app/Contents" -type f -print | while IFS= read -r nested_code; do
+    [ "$nested_code" != "$main" ] || continue
+    /usr/bin/file -b "$nested_code" | /usr/bin/grep -q 'Mach-O' || continue
+    sign_nested "$nested_code"
+done
+
+# Then sign nested bundle containers from the inside out. Do not use
+# `codesign --deep` for signing; it cannot preserve intentional bundle policy.
+/usr/bin/find "$app/Contents" -depth -type d \
+    \( -name '*.framework' -o -name '*.app' -o -name '*.xpc' \
+    -o -name '*.appex' -o -name '*.plugin' \) -print |
+    while IFS= read -r nested_bundle; do
+        sign_nested "$nested_bundle"
+    done
+
+if [ -n "$profile" ]; then
+    /usr/bin/codesign \
+        --force \
+        --sign "$signing_identity" \
+        --identifier "$bundle_id" \
+        --entitlements "$entitlements" \
+        --options runtime \
+        "$timestamp" \
+        "$app"
+else
+    /usr/bin/codesign \
+        --force \
+        --sign "$signing_identity" \
+        --identifier "$bundle_id" \
+        --options runtime \
+        "$timestamp" \
+        "$app"
+fi
+
+/usr/bin/codesign --verify --deep --strict --verbose=2 "$app"
+if [ -n "$profile" ]; then
+    signed_entitlements="$scratch/signed-entitlements.plist"
+    /usr/bin/codesign -d --entitlements - --xml "$app" >"$signed_entitlements"
+    [ "$(/usr/libexec/PlistBuddy -c 'Print :com.apple.application-identifier' "$signed_entitlements")" = "$application_id" ]
+    [ "$(/usr/libexec/PlistBuddy -c 'Print :com.apple.developer.team-identifier' "$signed_entitlements")" = "$team_id" ]
+    [ "$(/usr/libexec/PlistBuddy -c 'Print :keychain-access-groups:0' "$signed_entitlements")" = "$application_id" ]
+    signature_details=$(/usr/bin/codesign -dvvv "$app" 2>&1)
+    signed_team_id=$(printf '%s\n' "$signature_details" | /usr/bin/sed -n 's/^TeamIdentifier=//p')
+    [ "$signed_team_id" = "$team_id" ] || {
+        echo "signature Team ID $signed_team_id does not match profile Team ID $team_id" >&2
+        exit 1
+    }
+    case $identity_name in
+        'Developer ID Application:'*)
+            printf '%s\n' "$signature_details" | /usr/bin/grep -q '^Timestamp=' || {
+                echo "Developer ID signature has no secure timestamp" >&2
+                exit 1
+            }
+            ;;
+    esac
+    echo "Signed $app as $application_id with team $team_id"
+else
+    echo "Locally signed $app for packaging checks only."
+    echo "This app cannot use Factorseal's protected macOS Keychain storage or pass physical acceptance."
+fi

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -209,28 +209,27 @@ fn the_macos_launcher_and_packager_agree_on_the_askpass_helper() {
     let plist = packaging("macos/dev.factorseal.plist");
     let builder = packaging("build-unix.sh");
 
-    // The helper must sit in the same installed directory as the binary the
-    // LaunchAgent starts, so one relocation cannot move only one of them.
+    // Keep the script in Resources so the outer app signature seals it as a
+    // resource instead of treating it as unsigned nested code in MacOS.
     let helper = plist_askpass_argument(&plist);
     let factorseal = "/Applications/Factorseal.app/Contents/MacOS/factorseal";
     assert!(
         plist.contains(factorseal),
         "the LaunchAgent no longer starts the expected binary"
     );
-    assert_eq!(
-        Path::new(&helper).parent(),
-        Path::new(factorseal).parent(),
-        "the askpass helper is not installed beside the Factorseal binary"
+    assert!(
+        helper.starts_with("/Applications/Factorseal.app/Contents/Resources/"),
+        "the askpass helper is not installed as a signed app resource: {helper}"
     );
 
     // ...and the packager must actually put it there.
     let name = Path::new(&helper).file_name().unwrap().to_str().unwrap();
     assert!(
-        builder.contains(&format!("cp packaging/macos/{name} \"$app/MacOS/\"")),
+        builder.contains(&format!("cp packaging/macos/{name} \"$app/Resources/\"")),
         "build-unix.sh does not install {name} into the app bundle"
     );
     assert!(
-        builder.contains(&format!("\"$app/MacOS/{name}\"")),
+        builder.contains(&format!("\"$app/Resources/{name}\"")),
         "build-unix.sh does not make {name} executable"
     );
     assert!(
@@ -435,16 +434,43 @@ fn every_release_archive_ships_a_one_command_acceptance_runner() {
 }
 
 #[test]
-fn macos_builds_require_a_profile_and_embed_keychain_entitlements_before_signing() {
+fn macos_builds_support_local_and_team_signing() {
     let builder = packaging("build-unix.sh");
+    let preparer = packaging("macos/prepare-app.sh");
+    let signer = packaging("macos/sign-app.sh");
     let entitlements = packaging("macos/Factorseal.entitlements.in");
 
     assert!(builder.contains("FACTORSEAL_MACOS_SIGNING_IDENTITY"));
     assert!(builder.contains("FACTORSEAL_MACOS_PROVISIONING_PROFILE"));
-    assert!(builder.contains("macOS packaging requires FACTORSEAL_MACOS_SIGNING_IDENTITY"));
-    assert!(builder.contains("embedded.provisionprofile"));
-    assert!(builder.contains("--entitlements \"$entitlements\""));
+    assert!(builder.contains("FACTORSEAL_MACOS_PROVISIONING_PROFILE is required"));
+    assert!(builder.contains("FACTORSEAL_MACOS_SIGNING_IDENTITY is required"));
+    assert!(builder.contains("signing_identity=-"));
+    assert!(signer.contains("Contents/embedded.provisionprofile"));
+    assert!(signer.contains("rm -f \"$app/Contents/embedded.provisionprofile\""));
+    assert!(signer.contains("--entitlements \"$entitlements\""));
+    assert!(signer.contains("codesign --verify --deep --strict"));
+    assert!(signer.contains("find \"$app/Contents\" -type f"));
+    assert!(signer.contains("find \"$app/Contents\" -depth -type d"));
+    assert!(signer.contains("DeveloperCertificates.$certificate_index"));
+    assert!(signer.contains("This app cannot use Factorseal's protected macOS Keychain storage"));
     assert!(entitlements.contains("com.apple.application-identifier"));
     assert!(entitlements.contains("com.apple.developer.team-identifier"));
-    assert_eq!(entitlements.matches("@TEAM_ID@.dev.factorseal").count(), 1);
+    assert!(entitlements.contains("keychain-access-groups"));
+    assert_eq!(entitlements.matches("@APPLICATION_ID@").count(), 2);
+
+    assert!(builder.contains("macos_deployment_target=11.0"));
+    assert!(builder.contains("MACOSX_DEPLOYMENT_TARGET=$macos_deployment_target"));
+    assert!(preparer.contains("install_name_tool -change"));
+    assert!(preparer.contains("/usr/lib/libiconv.2.dylib"));
+    assert!(preparer.contains("otool -l"));
+    assert!(preparer.contains("/nix/store/"));
+    assert!(preparer.contains("expected macOS deployment target $deployment_target in $candidate"));
+
+    let assemble = builder
+        .find("cp packaging/macos/factorseal-askpass")
+        .unwrap();
+    let prepare = builder.find("sh packaging/macos/prepare-app.sh").unwrap();
+    let sign = builder.find("sh packaging/macos/sign-app.sh").unwrap();
+    let archive = builder.find("tar -C \"$stage\"").unwrap();
+    assert!(assemble < prepare && prepare < sign && sign < archive);
 }


### PR DESCRIPTION
Adds the appropriate entitlements, signs the binary, supports both team and self-signing.

Also fixes a bug preventing items from being cleaned up from the keychain.