### PR TITLE
Seal vault on screen lock and suspend

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -31,10 +31,12 @@ preflight.
 ./run-acceptance.sh
 ```
 
-Approve the Touch ID/macOS verification dialogs. The default run tests screen
-lock. Separate sleep and session-switch results are just as simple:
+Approve the Touch ID/macOS verification dialogs. The default run tests both
+screen lock and sleep, with a successful re-unseal between them. A focused
+single-event diagnostic or an additional session-switch result can use:
 
 ```console
+./run-acceptance.sh --event lock
 ./run-acceptance.sh --event sleep
 ./run-acceptance.sh --event switch
 ```
@@ -72,8 +74,8 @@ With no options, the runner finds the bundled Factorseal binary, chooses unique
 test and evidence paths, generates a random test-only factor, and destroys the
 test vault and native test key after a successful run. It never touches an
 existing Factorseal vault. The only manual actions are approving native prompts,
-locking and unlocking the session when instructed, and confirming that the
-prompts appeared.
+locking and unlocking the session, suspending and resuming the machine when
+instructed, and confirming that the prompts appeared.
 
 At the end it prints one line beginning with `PASS` and the path to a single
 `.acceptance.txt` file. Attach only that file to
@@ -106,9 +108,12 @@ creation and unseal; Linux validates the TPM plus nested password. They verify:
    times;
 4. the native transport permits an authorized local CLI to put, get, and delete
    an exact-byte value;
-5. a real OS lock, sleep, shutdown-preparation, or session event causes the
-   live vault process to exit and the socket/pipe to become sealed;
-6. the same vault can be unsealed again and recover the stored value.
+5. a real screen lock causes the live vault process to exit, leaves the
+   socket/pipe sealed, and denies reads;
+6. after a successful recovery unseal, a real suspend/resume independently
+   causes the live vault process to exit, leaves the socket/pipe sealed, and
+   denies reads;
+7. the same vault can be unsealed again and recover the stored value.
 
 Run the script from the account that will own the release installation. The
 zero-option guided mode is preferred for volunteer testing. Release engineers
@@ -131,7 +136,8 @@ password, test secret, or username. Never overwrite an existing record.
 
 Use the package-installed binary and ensure the user is in an active logind
 session with access to the real TPM. The runner asks you to lock the current
-session. It must be invoked from a terminal which survives the lock event.
+session and then suspend the machine. It must be invoked from a terminal which
+survives both lifecycle events.
 
 ```console
 ./run-acceptance.sh \
@@ -154,9 +160,10 @@ coverage only; it does not replace this protocol.
 ## Advanced macOS invocation
 
 Run against `/Applications/Factorseal.app/Contents/MacOS/factorseal` on a
-physical Secure Enclave-capable Mac. The runner asks you to lock/switch away or
-sleep the Mac, then waits for the vault to seal. Separately validate the signed
-and notarized app by logging in with its LaunchAgent enabled and confirming the
+physical Secure Enclave-capable Mac. By default the runner asks you to lock and
+then sleep the Mac, checking a fresh unseal between events. Separately validate
+the signed and notarized app by logging in with its LaunchAgent enabled and
+confirming the
 askpass dialog works without a terminal.
 
 ```console
@@ -164,7 +171,7 @@ askpass dialog works without a terminal.
   --factorseal /Applications/Factorseal.app/Contents/MacOS/factorseal \
   --root "$HOME/Library/Application Support/Factorseal-acceptance" \
   --password-file "$HOME/.factorseal-acceptance-password" \
-  --event lock \
+  --event all \
   --evidence "$HOME/factorseal-macos.acceptance.txt"
 ```
 
@@ -174,9 +181,10 @@ The archive runner prefers its sibling app bundle, then the app installed in
 ## Advanced Windows invocation
 
 Run from an interactive, standard-user PowerShell session on a TPM 2.0 machine.
-The runner asks you to lock the current session, then waits for the vault
-process to exit. It must visibly exercise Windows Hello user verification and
-confirm the platform credential reports PRF support. Verify the candidate's
+The runner asks you to lock the current session and later suspend the machine,
+waiting for the vault process to exit after each event. It must visibly
+exercise Windows Hello user verification and confirm the platform credential
+reports PRF support. Verify the candidate's
 Authenticode status before creating any test state:
 
 ```powershell
@@ -231,7 +239,7 @@ Unregister-ScheduledTask -TaskName Factorseal -Confirm:$false
 Repeat the installed-service observation for sleep, logout/disconnect, and
 shutdown preparation. Shutdown and cross-device copied-vault tests necessarily
 resume after a reboot or on a second physical machine; record them in the
-template rather than treating the guided lock runner as the entire release
+template rather than treating the guided runner as the entire release
 matrix. Also verify that cancelling and allowing the Windows Hello ceremony to
 time out leave the vault sealed.
 
@@ -240,10 +248,11 @@ time out leave the vault sealed.
 For every supported OS/hardware combination, attach the generated evidence
 record, redacted script output, and a completed copy of
 [the release acceptance record](results-template.md) to the release approval.
-The generated file covers the repeatable core test; the template records
-signature verification, installed-service behavior, and the additional
-lifecycle events that require separate runs. A pass requires all lifecycle
-events named above, a verified real backend, an observed native user-verification
-prompt where policy requires one, and a successful re-unseal. Treat a missing
+The generated file covers the repeatable lock-and-suspend core test; the
+template records signature verification, installed-service behavior, and the
+additional logout and shutdown events that require separate runs. A pass
+requires all lifecycle events named above, a verified real backend, an observed
+native user-verification prompt where policy requires one, and a successful
+re-unseal. Treat a missing
 prompt, software fallback, inability to seal, or a failure to re-unseal as a
 release blocker.

--- a/acceptance/linux.sh
+++ b/acceptance/linux.sh
@@ -125,7 +125,7 @@ record expected_backend tpm
 record physical_host_check pass
 record hardware_summary "$(cat /sys/class/tpm/tpm0/device/description 2>/dev/null || printf 'TPM 2.0 at /dev/tpmrm0')"
 record native_prompt_observed not-applicable
-record lifecycle_event logind-lock
+record lifecycle_event logind-lock,logind-suspend
 
 status() { "$factorseal" --root "$root" status; }
 wait_for() {
@@ -181,11 +181,30 @@ printf 'Press Enter after the lock/unlock: '
 read -r _
 wait_for_vault_exit
 wait_for sealed
-record test.lifecycle_seal pass
+record test.screen_lock_seal pass
 if "$factorseal" --root "$root" get --project acceptance acceptance --field value >/dev/null 2>&1; then
     echo "sealed vault returned a secret" >&2
     exit 1
 fi
+
+"$factorseal" --root "$root" --password-file "$password_file" \
+    agent --idle-seconds 3600 --maximum-seconds 3600 >"$root/acceptance-after-lock.log" 2>&1 &
+vault_pid=$!
+wait_for unsealed
+[ "$("$factorseal" --root "$root" get --project acceptance acceptance --field value)" = "hardware-lifecycle-acceptance" ]
+
+echo "Suspend this machine now using the desktop power menu (or: systemctl suspend)."
+echo "After the machine resumes, return here and press Enter."
+printf 'Press Enter after suspend/resume: '
+read -r _
+wait_for_vault_exit
+wait_for sealed
+record test.suspend_seal pass
+if "$factorseal" --root "$root" get --project acceptance acceptance --field value >/dev/null 2>&1; then
+    echo "suspended vault returned a secret after resume" >&2
+    exit 1
+fi
+record test.lifecycle_seal pass
 record test.sealed_read_denied pass
 
 "$factorseal" --root "$root" --password-file "$password_file" \

--- a/acceptance/macos.sh
+++ b/acceptance/macos.sh
@@ -4,7 +4,7 @@ set -eu
 umask 077
 
 usage() {
-    echo "usage: $0 [--factorseal PATH] [--root ABSOLUTE_PATH] [--password-file PATH] [--event lock|switch|sleep] [--evidence ABSOLUTE_PATH] [--destroy-after]" >&2
+    echo "usage: $0 [--factorseal PATH] [--root ABSOLUTE_PATH] [--password-file PATH] [--event all|lock|switch|sleep] [--evidence ABSOLUTE_PATH] [--destroy-after]" >&2
     exit "${1:-2}"
 }
 
@@ -12,7 +12,7 @@ factorseal=
 root=
 password_file=
 evidence=
-lifecycle_event=lock
+lifecycle_event=all
 destroy_after=false
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -47,7 +47,7 @@ socket="${TMPDIR:-/tmp}/fs-$run_id.sock"
 [ "${root#/}" != "$root" ] || usage
 [ ! -e "$root" ] || { echo "acceptance root already exists: $root" >&2; exit 2; }
 [ -z "$password_file" ] || [ -f "$password_file" ] || usage
-case $lifecycle_event in lock|switch|sleep) ;; *) usage ;; esac
+case $lifecycle_event in all|lock|switch|sleep) ;; *) usage ;; esac
 
 case $factorseal in
     */Contents/MacOS/*) app_bundle=${factorseal%/Contents/MacOS/*} ;;
@@ -179,7 +179,11 @@ record os_summary "macOS $(sw_vers -productVersion); $(uname -m)"
 record expected_backend secure-enclave
 record physical_host_check pass
 record hardware_summary "$hardware_summary"
-record lifecycle_event "$lifecycle_event"
+case $lifecycle_event in
+    all) lifecycle_events="lock sleep" ;;
+    *) lifecycle_events=$lifecycle_event ;;
+esac
+record lifecycle_event "$(printf '%s' "$lifecycle_events" | tr ' ' ',')"
 
 run_factorseal() { "$factorseal" --root "$root" --socket "$socket" "$@"; }
 status() { run_factorseal status; }
@@ -238,24 +242,49 @@ printf '%s' 'hardware-lifecycle-acceptance' | run_factorseal set --project accep
 [ "$(run_factorseal get --project acceptance acceptance --field value)" = "hardware-lifecycle-acceptance" ]
 record test.ipc_round_trip pass
 
-echo "Trigger the requested macOS lifecycle event now: $lifecycle_event."
-echo "After returning to this session, press Enter."
-printf 'Press Enter after the lifecycle event: '
-read -r _
-wait_for_vault_exit
-wait_for sealed
-record test.lifecycle_seal pass
-if run_factorseal get --project acceptance acceptance --field value >/dev/null 2>&1; then
-    echo "sealed vault returned a secret" >&2
-    exit 1
-fi
-record test.sealed_read_denied pass
+screen_lock_result=not-run
+suspend_result=not-run
+session_switch_result=not-run
+for event in $lifecycle_events; do
+    case $event in
+        lock)
+            echo "Lock this Mac now, then unlock it and return here."
+            prompt="Press Enter after screen lock/unlock: "
+            ;;
+        sleep)
+            echo "Put this Mac to sleep now, then wake it and return here."
+            prompt="Press Enter after sleep/wake: "
+            ;;
+        switch)
+            echo "Switch away from this macOS login session now, then return here."
+            prompt="Press Enter after switching away and back: "
+            ;;
+    esac
+    printf '%s' "$prompt"
+    read -r _
+    wait_for_vault_exit
+    wait_for sealed
+    if run_factorseal get --project acceptance acceptance --field value >/dev/null 2>&1; then
+        echo "$event left the vault able to return a secret" >&2
+        exit 1
+    fi
+    case $event in
+        lock) screen_lock_result=pass ;;
+        sleep) suspend_result=pass ;;
+        switch) session_switch_result=pass ;;
+    esac
 
-run_factorseal --password-file "$password_file" \
-    agent --idle-seconds 3600 --maximum-seconds 3600 >"$root/acceptance-reunseal.log" 2>&1 &
-vault_pid=$!
-wait_for unsealed
-[ "$(run_factorseal get --project acceptance acceptance --field value)" = "hardware-lifecycle-acceptance" ]
+    run_factorseal --password-file "$password_file" \
+        agent --idle-seconds 3600 --maximum-seconds 3600 >"$root/acceptance-after-$event.log" 2>&1 &
+    vault_pid=$!
+    wait_for unsealed
+    [ "$(run_factorseal get --project acceptance acceptance --field value)" = "hardware-lifecycle-acceptance" ]
+done
+record test.screen_lock_seal "$screen_lock_result"
+record test.suspend_seal "$suspend_result"
+record test.session_switch_seal "$session_switch_result"
+record test.lifecycle_seal pass
+record test.sealed_read_denied pass
 record test.reunseal_recovery pass
 run_factorseal delete --project acceptance acceptance --field value
 record test.delete pass

--- a/acceptance/windows.ps1
+++ b/acceptance/windows.ps1
@@ -173,7 +173,7 @@ Add-Evidence 'os_summary' ([System.Environment]::OSVersion.VersionString)
 Add-Evidence 'expected_backend' 'windows-tpm'
 Add-Evidence 'physical_host_check' 'pass'
 Add-Evidence 'hardware_summary' "$hardwareSummary; TPM present and ready"
-Add-Evidence 'lifecycle_event' 'windows-session-lock'
+Add-Evidence 'lifecycle_event' 'windows-session-lock,windows-suspend'
 
 $generatedPasswordFile = $false
 $destroyAfterRun = $DestroyAfter.IsPresent
@@ -264,11 +264,33 @@ Write-Host 'After unlocking again, return here and press Enter.'
 $service.WaitForExit(180000)
 if (-not $service.HasExited) { throw 'Vault did not exit after the lifecycle event' }
 Wait-ForState 'sealed'
-Add-Evidence 'test.lifecycle_seal' 'pass'
+Add-Evidence 'test.screen_lock_seal' 'pass'
 $sealedValue = & $Factorseal --root $Root get --project acceptance acceptance --field value 2>$null
 if ($LASTEXITCODE -eq 0 -or $sealedValue) {
     throw 'Sealed vault returned a secret'
 }
+
+$service = Start-FactorsealAgent `
+    (Join-Path $Root 'acceptance-after-lock.log') `
+    (Join-Path $Root 'acceptance-after-lock-error.log')
+Wait-ForState 'unsealed'
+$value = & $Factorseal --root $Root get --project acceptance acceptance --field value
+if ($LASTEXITCODE -ne 0 -or $value -ne 'hardware-lifecycle-acceptance') {
+    throw 'Re-unseal after screen lock did not recover the stored value'
+}
+
+Write-Host 'Put this machine to sleep now (Start > Power > Sleep).'
+Write-Host 'After it resumes, return here and press Enter.'
+[void](Read-Host 'Press Enter after suspend/resume')
+$service.WaitForExit(180000)
+if (-not $service.HasExited) { throw 'Vault did not exit after suspend/resume' }
+Wait-ForState 'sealed'
+Add-Evidence 'test.suspend_seal' 'pass'
+$sealedValue = & $Factorseal --root $Root get --project acceptance acceptance --field value 2>$null
+if ($LASTEXITCODE -eq 0 -or $sealedValue) {
+    throw 'Suspended vault returned a secret after resume'
+}
+Add-Evidence 'test.lifecycle_seal' 'pass'
 Add-Evidence 'test.sealed_read_denied' 'pass'
 
 $service = Start-FactorsealAgent `
@@ -277,7 +299,7 @@ $service = Start-FactorsealAgent `
 Wait-ForState 'unsealed'
 $value = & $Factorseal --root $Root get --project acceptance acceptance --field value
 if ($LASTEXITCODE -ne 0 -or $value -ne 'hardware-lifecycle-acceptance') {
-    throw 'Hardware re-unseal did not recover the stored value'
+    throw 'Hardware re-unseal after suspend did not recover the stored value'
 }
 Add-Evidence 'test.reunseal_recovery' 'pass'
 & $Factorseal --root $Root delete --project acceptance acceptance --field value

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -247,11 +247,19 @@ The shared core implements the following native adapters:
   impersonation, SID, PID, and executable digest, plus a per-user Scheduled
   Task template.
 
-- Linux subscribes to logind session-lock and pre-sleep/pre-shutdown signals
-  while holding a delay inhibitor until the vault is sealed;
-- macOS observes AppKit sleep, power-off, and session-resign notifications;
-- Windows registers a hidden-window power/session listener and seals directly
-  from suspend, shutdown, session-lock, logout, and disconnect callbacks.
+- Linux watches `LockedHint` for every logind session owned by the user, with
+  session-lock signals as an eager fallback, and holds a delay inhibitor across
+  pre-sleep/pre-shutdown sealing;
+- macOS checks the Core Graphics login-session lock state and observes AppKit
+  sleep, wake, power-off, and session-resign notifications;
+- Windows registers a hidden-window power/session listener, checks the initial
+  WTS lock state, and seals on suspend/resume, shutdown, session lock, logout,
+  and disconnect. A suspend deadline aborts the process if synchronous store
+  shutdown cannot finish inside Windows' callback window.
+
+All three lifecycle subscriptions are installed and armed before native
+authorization begins. Events during authorization or database opening latch;
+the new service seals before its IPC listener can accept a request.
 
 The transports, lifecycle monitors, and developer packaging inputs are
 implemented. Code-signature identities, official signing/notarization, and

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -228,9 +228,11 @@ because CI cannot demonstrate the native prompt or hardware boundary.
 
 ## Native lifecycle scope
 
-The vault registers native lifecycle monitors on every target: logind with a
-delay inhibitor on Linux, AppKit workspace notifications on macOS, and Windows
-power/session notifications through a hidden top-level window. The supplied
-service definitions also cover logout and orderly stop. Until real installed
-artifacts prove these paths during suspend, shutdown, logout, and session lock,
-the packages remain development artifacts.
+The vault registers native lifecycle monitors on every target: logind lock
+state with a delay inhibitor on Linux, Core Graphics lock state plus AppKit
+workspace notifications on macOS, and Windows power/session notifications
+through a hidden top-level window. The guided physical acceptance runners prove
+screen lock and suspend independently, with a recovery unseal between them.
+The supplied service definitions also cover logout and orderly stop. Until real
+installed artifacts prove the remaining shutdown and logout paths, the packages
+remain development artifacts.

--- a/src/bin/factorseal/commands.rs
+++ b/src/bin/factorseal/commands.rs
@@ -20,7 +20,9 @@ use zeroize::Zeroizing;
 
 use super::cli::PermissionCommand;
 use super::factor::{FactorSource, read_factor};
-use super::platform::{caller_identity_for_executable, native_client, serve_vault};
+use super::platform::{
+    caller_identity_for_executable, native_client, prepare_lifecycle, serve_vault,
+};
 use super::{CLI_CONTROL_NAMESPACE, CliError, MAX_PROJECT_VALUE_BYTES, PROJECT_PERMISSIONS};
 
 #[derive(Serialize)]
@@ -626,9 +628,15 @@ pub(super) fn run_agent(
 ) -> Result<(), CliError> {
     wait_for_initialization(root, INITIALIZATION_POLL_INTERVAL);
     let device = Vault::inspect(root)?;
-    let unsealed = unseal_selected(root, &device, requested_group, factor)?;
-    let service = Arc::new(VaultService::open(root, unsealed, unix_time()?, policy)?);
-    serve_vault(&device, &service, root, socket)
+    let lifecycle = prepare_lifecycle()?;
+    lifecycle.arm()?;
+    let result = (|| {
+        let unsealed = unseal_selected(root, &device, requested_group, factor)?;
+        let service = Arc::new(VaultService::open(root, unsealed, unix_time()?, policy)?);
+        serve_vault(&device, &service, root, socket, &lifecycle)
+    })();
+    lifecycle.disarm();
+    result
 }
 
 pub(super) fn wait_for_initialization(root: &Path, poll_interval: Duration) {

--- a/src/bin/factorseal/platform.rs
+++ b/src/bin/factorseal/platform.rs
@@ -8,21 +8,44 @@ use factorseal::Vault;
 use factorseal::{CallerIdentity, NativeVaultClient, VaultMetadata, VaultService};
 #[cfg(target_os = "linux")]
 use factorseal::{
-    LinuxVaultClient, LinuxVaultOptions, linux_caller_identity_for_executable, serve_linux_vault,
+    LinuxVaultClient, LinuxVaultLifecycle, LinuxVaultOptions, linux_caller_identity_for_executable,
+    serve_linux_vault_with_lifecycle,
 };
 #[cfg(target_os = "macos")]
 use factorseal::{
-    MacosVaultClient, MacosVaultOptions, macos_caller_identity_for_executable, serve_macos_vault,
+    MacosVaultClient, MacosVaultLifecycle, MacosVaultOptions, macos_caller_identity_for_executable,
+    serve_macos_vault_with_lifecycle,
 };
 #[cfg(target_os = "windows")]
 use factorseal::{
-    WindowsVaultClient, WindowsVaultOptions, default_windows_pipe_name, serve_windows_vault,
-    windows_caller_identity_for_executable,
+    WindowsVaultClient, WindowsVaultLifecycle, WindowsVaultOptions, default_windows_pipe_name,
+    serve_windows_vault_with_lifecycle, windows_caller_identity_for_executable,
 };
 
 use super::CliError;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use super::DEFAULT_UNIX_SOCKET;
+
+#[cfg(target_os = "linux")]
+pub(super) type NativeVaultLifecycle = LinuxVaultLifecycle;
+#[cfg(target_os = "macos")]
+pub(super) type NativeVaultLifecycle = MacosVaultLifecycle;
+#[cfg(target_os = "windows")]
+pub(super) type NativeVaultLifecycle = WindowsVaultLifecycle;
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+pub(super) fn prepare_lifecycle() -> Result<NativeVaultLifecycle, CliError> {
+    Ok(NativeVaultLifecycle::new()?)
+}
+
+#[cfg(target_os = "macos")]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "Linux and Windows lifecycle setup is fallible at the shared call site"
+)]
+pub(super) fn prepare_lifecycle() -> Result<NativeVaultLifecycle, CliError> {
+    Ok(NativeVaultLifecycle::new())
+}
 
 #[cfg(target_os = "linux")]
 #[expect(
@@ -70,9 +93,10 @@ pub(super) fn serve_vault(
     service: &Arc<VaultService>,
     root: &Path,
     socket: Option<&Path>,
+    lifecycle: &NativeVaultLifecycle,
 ) -> Result<(), CliError> {
     let socket = socket.map_or_else(|| root.join(DEFAULT_UNIX_SOCKET), Path::to_owned);
-    serve_linux_vault(service, &LinuxVaultOptions::new(socket))?;
+    serve_linux_vault_with_lifecycle(service, &LinuxVaultOptions::new(socket), Some(lifecycle))?;
     Ok(())
 }
 
@@ -82,9 +106,10 @@ pub(super) fn serve_vault(
     service: &Arc<VaultService>,
     root: &Path,
     socket: Option<&Path>,
+    lifecycle: &NativeVaultLifecycle,
 ) -> Result<(), CliError> {
     let socket = socket.map_or_else(|| root.join(DEFAULT_UNIX_SOCKET), Path::to_owned);
-    serve_macos_vault(service, &MacosVaultOptions::new(socket))?;
+    serve_macos_vault_with_lifecycle(service, &MacosVaultOptions::new(socket), Some(lifecycle))?;
     Ok(())
 }
 
@@ -94,12 +119,17 @@ pub(super) fn serve_vault(
     service: &Arc<VaultService>,
     _root: &Path,
     socket: Option<&Path>,
+    lifecycle: &NativeVaultLifecycle,
 ) -> Result<(), CliError> {
     let pipe_name = socket.map_or_else(
         || default_windows_pipe_name(device.vault_id()),
         |path| path.to_string_lossy().into_owned(),
     );
-    serve_windows_vault(service, &WindowsVaultOptions::new(pipe_name))?;
+    serve_windows_vault_with_lifecycle(
+        service,
+        &WindowsVaultOptions::new(pipe_name),
+        Some(lifecycle),
+    )?;
     Ok(())
 }
 
@@ -109,6 +139,7 @@ pub(super) fn serve_vault(
     _service: &Arc<VaultService>,
     _root: &Path,
     _socket: Option<&Path>,
+    _lifecycle: &(),
 ) -> Result<(), CliError> {
     Err(CliError::UnsupportedPlatform)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,10 @@ pub use vault::LinuxVaultClient;
 pub type NativeVaultClient = LinuxVaultClient;
 
 #[cfg(all(feature = "vault", target_os = "linux"))]
-pub use vault::{LinuxVaultOptions, linux_caller_identity_for_executable, serve_linux_vault};
+pub use vault::{
+    LinuxVaultLifecycle, LinuxVaultOptions, linux_caller_identity_for_executable,
+    serve_linux_vault, serve_linux_vault_with_lifecycle,
+};
 
 #[cfg(all(feature = "vault-client", target_os = "macos"))]
 pub use vault::MacosVaultClient;
@@ -69,7 +72,10 @@ pub use vault::MacosVaultClient;
 pub type NativeVaultClient = MacosVaultClient;
 
 #[cfg(all(feature = "vault", target_os = "macos"))]
-pub use vault::{MacosVaultOptions, macos_caller_identity_for_executable, serve_macos_vault};
+pub use vault::{
+    MacosVaultLifecycle, MacosVaultOptions, macos_caller_identity_for_executable,
+    serve_macos_vault, serve_macos_vault_with_lifecycle,
+};
 
 #[cfg(all(feature = "vault-client", target_os = "windows"))]
 pub use vault::{WindowsVaultClient, default_windows_pipe_name};
@@ -77,7 +83,10 @@ pub use vault::{WindowsVaultClient, default_windows_pipe_name};
 pub type NativeVaultClient = WindowsVaultClient;
 
 #[cfg(all(feature = "vault", target_os = "windows"))]
-pub use vault::{WindowsVaultOptions, serve_windows_vault, windows_caller_identity_for_executable};
+pub use vault::{
+    WindowsVaultLifecycle, WindowsVaultOptions, serve_windows_vault,
+    serve_windows_vault_with_lifecycle, windows_caller_identity_for_executable,
+};
 
 #[cfg(feature = "hardware")]
 mod hardware;

--- a/src/vault/linux.rs
+++ b/src/vault/linux.rs
@@ -1,15 +1,19 @@
+use std::collections::HashSet;
 use std::fs::{self, File};
 use std::os::unix::fs::MetadataExt;
 #[cfg(test)]
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::sync_channel;
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
 use std::time::Duration;
 
 use dbus::Path as DbusPath;
-use dbus::arg::OwnedFd;
+use dbus::arg::{OwnedFd, PropMap};
+use dbus::blocking::stdintf::org_freedesktop_dbus::Properties;
 use dbus::blocking::{Connection, Proxy};
 use dbus::message::MatchRule;
 use nix::sys::socket::{getsockopt, sockopt::PeerCredentials};
@@ -22,13 +26,15 @@ use super::transport::unix_socket::{
 use super::transport::unix_time;
 use super::transport::{hash_file, hash_open_file, path_io_error};
 use super::{
-    CallerIdentity, CallerIdentityCache, CallerPlatform, VaultError, VaultResult, VaultService,
+    CallerIdentity, CallerIdentityCache, CallerPlatform, LifecycleSignal, VaultError, VaultResult,
+    VaultService,
 };
 #[cfg(all(test, feature = "hardware"))]
 use super::{LinuxVaultClient, VaultClient, VaultRequest};
 
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const LIFECYCLE_DBUS_TIMEOUT: Duration = Duration::from_secs(5);
+const LOGIND_SEAL_DEADLINE: Duration = Duration::from_secs(4);
 const SESSION_ID_ENVIRONMENT: [&str; 2] = ["FACTORSEAL_SESSION_ID", "XDG_SESSION_ID"];
 
 /// Linux per-user socket configuration.
@@ -70,15 +76,38 @@ pub fn serve_linux_vault(
     service: &Arc<VaultService>,
     options: &LinuxVaultOptions,
 ) -> VaultResult<()> {
+    let lifecycle = options
+        .install_lifecycle_monitor
+        .then(LinuxVaultLifecycle::new)
+        .transpose()?;
+    if let Some(lifecycle) = lifecycle.as_ref() {
+        lifecycle.arm()?;
+    }
+    let result = serve_linux_vault_with_lifecycle(service, options, lifecycle.as_ref());
+    if let Some(lifecycle) = lifecycle.as_ref() {
+        lifecycle.disarm();
+    }
+    result
+}
+
+/// Serve with a lifecycle subscription established before vault unsealing.
+#[doc(hidden)]
+pub fn serve_linux_vault_with_lifecycle(
+    service: &Arc<VaultService>,
+    options: &LinuxVaultOptions,
+    lifecycle_monitor: Option<&LinuxVaultLifecycle>,
+) -> VaultResult<()> {
     validate_socket_options("Linux", &options.socket_path, options.poll_interval)?;
     let (listener, _socket_guard) = bind_listener(&options.socket_path)?;
 
     let stopping = Arc::new(AtomicBool::new(false));
-    let lifecycle_seal_requested = Arc::new(AtomicBool::new(false));
-    let lifecycle_monitor = options
-        .install_lifecycle_monitor
-        .then(|| LinuxLifecycleMonitor::new(&lifecycle_seal_requested))
-        .transpose()?;
+    if let Some(monitor) = lifecycle_monitor {
+        monitor.attach(service)?;
+    } else if options.install_lifecycle_monitor {
+        return Err(VaultError::Protocol(
+            "Linux lifecycle monitor was not prepared".to_owned(),
+        ));
+    }
     if options.install_signal_handler {
         install_shutdown_signal_handler(&stopping)?;
     }
@@ -104,12 +133,7 @@ pub fn serve_linux_vault(
             &stopping,
             &options.socket_path,
             options.poll_interval,
-            || {
-                if let Some(monitor) = lifecycle_monitor.as_ref() {
-                    monitor.process()?;
-                }
-                Ok(lifecycle_seal_requested.load(Ordering::Acquire))
-            },
+            || Ok(lifecycle_monitor.is_some_and(LinuxVaultLifecycle::requested)),
             |stream| caller_identity(stream, &caller_cache),
         );
         stopping.store(true, Ordering::Release);
@@ -126,20 +150,110 @@ pub fn serve_linux_vault(
 
 /// Owns logind's delay inhibitor until the store has sealed. Dropping the
 /// returned file descriptor releases suspend or shutdown to continue.
-struct LinuxLifecycleMonitor {
-    connection: Connection,
-    _delay_inhibitor: OwnedFd,
+#[doc(hidden)]
+pub struct LinuxVaultLifecycle {
+    signal: Arc<LifecycleSignal>,
+    stopping: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
 }
 
-impl LinuxLifecycleMonitor {
-    fn new(lock_requested: &Arc<AtomicBool>) -> VaultResult<Self> {
+impl LinuxVaultLifecycle {
+    pub fn new() -> VaultResult<Self> {
+        let signal = Arc::new(LifecycleSignal::new());
+        let stopping = Arc::new(AtomicBool::new(false));
+        let (ready_sender, ready_receiver) = sync_channel(1);
+        let thread_signal = Arc::clone(&signal);
+        let thread_stopping = Arc::clone(&stopping);
+        let thread = std::thread::Builder::new()
+            .name("factorseal-linux-lifecycle".to_owned())
+            .spawn(move || {
+                let monitor = match LinuxLifecycleConnection::new(Arc::clone(&thread_signal)) {
+                    Ok(monitor) => {
+                        if ready_sender.send(Ok(())).is_err() {
+                            return;
+                        }
+                        monitor
+                    }
+                    Err(error) => {
+                        let _ = ready_sender.send(Err(error.to_string()));
+                        return;
+                    }
+                };
+                while !thread_stopping.load(Ordering::Acquire) {
+                    if monitor.process(DEFAULT_POLL_INTERVAL).is_err() {
+                        // Losing lifecycle monitoring is itself fail closed.
+                        thread_signal.trigger();
+                        abort_if_unsealed(&thread_signal);
+                        break;
+                    }
+                }
+            })
+            .map_err(|error| {
+                VaultError::Protocol(format!("could not start Linux lifecycle monitor: {error}"))
+            })?;
+        ready_receiver
+            .recv()
+            .map_err(|_| {
+                VaultError::Protocol("Linux lifecycle monitor stopped during startup".to_owned())
+            })?
+            .map_err(VaultError::Protocol)?;
+        Ok(Self {
+            signal,
+            stopping,
+            thread: Some(thread),
+        })
+    }
+
+    pub fn arm(&self) -> VaultResult<()> {
+        self.signal.arm()
+    }
+
+    pub fn disarm(&self) {
+        self.signal.disarm();
+    }
+
+    #[must_use]
+    pub fn requested(&self) -> bool {
+        self.signal.requested()
+    }
+
+    fn attach(&self, service: &Arc<VaultService>) -> VaultResult<()> {
+        self.signal.attach(service)
+    }
+}
+
+impl Drop for LinuxVaultLifecycle {
+    fn drop(&mut self) {
+        self.stopping.store(true, Ordering::Release);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+struct LinuxLifecycleConnection {
+    connection: Connection,
+    _delay_inhibitor: OwnedFd,
+    signal: Arc<LifecycleSignal>,
+    session_paths: Arc<Mutex<HashSet<String>>>,
+    sessions_changed: Arc<AtomicBool>,
+}
+
+impl LinuxLifecycleConnection {
+    #[expect(
+        clippy::too_many_lines,
+        reason = "keeping all logind registrations together makes their fail-closed setup auditable"
+    )]
+    fn new(signal: Arc<LifecycleSignal>) -> VaultResult<Self> {
         let connection = Connection::new_system().map_err(|error| lifecycle_error(&error))?;
-        let manager = connection.with_proxy(
-            "org.freedesktop.login1",
-            "/org/freedesktop/login1",
-            LIFECYCLE_DBUS_TIMEOUT,
-        );
-        let (delay_inhibitor,): (OwnedFd,) = manager
+        let session_paths = Arc::new(Mutex::new(HashSet::new()));
+        let sessions_changed = Arc::new(AtomicBool::new(false));
+        let (delay_inhibitor,): (OwnedFd,) = connection
+            .with_proxy(
+                "org.freedesktop.login1",
+                "/org/freedesktop/login1",
+                LIFECYCLE_DBUS_TIMEOUT,
+            )
             .method_call(
                 "org.freedesktop.login1.Manager",
                 "Inhibit",
@@ -152,57 +266,132 @@ impl LinuxLifecycleMonitor {
             )
             .map_err(|error| lifecycle_error(&error))?;
 
-        for member in ["PrepareForSleep", "PrepareForShutdown"] {
-            let requested = Arc::clone(lock_requested);
+        let sleep_signal = Arc::clone(&signal);
+        connection
+            .add_match::<(bool,), _>(
+                MatchRule::new_signal("org.freedesktop.login1.Manager", "PrepareForSleep")
+                    .with_path("/org/freedesktop/login1"),
+                move |(starting,), _, _| {
+                    // The false edge is a resume fallback if the pre-sleep
+                    // edge was lost. A correctly handled true edge has
+                    // already stopped the process before this can arrive.
+                    if starting {
+                        start_logind_deadline(Arc::clone(&sleep_signal));
+                    }
+                    sleep_signal.trigger();
+                    if !starting {
+                        abort_if_unsealed(&sleep_signal);
+                    }
+                    true
+                },
+            )
+            .map_err(|error| lifecycle_error(&error))?;
+
+        let shutdown_signal = Arc::clone(&signal);
+        connection
+            .add_match::<(bool,), _>(
+                MatchRule::new_signal("org.freedesktop.login1.Manager", "PrepareForShutdown")
+                    .with_path("/org/freedesktop/login1"),
+                move |(starting,), _, _| {
+                    if starting {
+                        start_logind_deadline(Arc::clone(&shutdown_signal));
+                        shutdown_signal.trigger();
+                    }
+                    true
+                },
+            )
+            .map_err(|error| lifecycle_error(&error))?;
+
+        let lock_signal = Arc::clone(&signal);
+        let lock_paths = Arc::clone(&session_paths);
+        connection
+            .add_match::<(), _>(
+                MatchRule::new_signal("org.freedesktop.login1.Session", "Lock"),
+                move |(), _, message| {
+                    if message_path_is_tracked(
+                        message.path().map(|path| path.to_string()),
+                        &lock_paths,
+                    ) {
+                        lock_signal.trigger();
+                        abort_if_unsealed(&lock_signal);
+                    }
+                    true
+                },
+            )
+            .map_err(|error| lifecycle_error(&error))?;
+
+        let hint_signal = Arc::clone(&signal);
+        let hint_paths = Arc::clone(&session_paths);
+        connection
+            .add_match::<(String, PropMap, Vec<String>), _>(
+                MatchRule::new_signal("org.freedesktop.DBus.Properties", "PropertiesChanged"),
+                move |(interface, changed, _invalidated), _, message| {
+                    if interface == "org.freedesktop.login1.Session"
+                        && locked_hint_is_true(&changed)
+                        && message_path_is_tracked(
+                            message.path().map(|path| path.to_string()),
+                            &hint_paths,
+                        )
+                    {
+                        hint_signal.trigger();
+                        abort_if_unsealed(&hint_signal);
+                    }
+                    true
+                },
+            )
+            .map_err(|error| lifecycle_error(&error))?;
+
+        for member in ["SessionNew", "SessionRemoved"] {
+            let changed = Arc::clone(&sessions_changed);
             connection
-                .add_match::<(bool,), _>(
+                .add_match::<(String, DbusPath<'static>), _>(
                     MatchRule::new_signal("org.freedesktop.login1.Manager", member)
                         .with_path("/org/freedesktop/login1"),
-                    move |(starting,), _, _| {
-                        if starting {
-                            requested.store(true, Ordering::Release);
-                        }
+                    move |_, _, _| {
+                        changed.store(true, Ordering::Release);
                         true
                     },
                 )
                 .map_err(|error| lifecycle_error(&error))?;
         }
 
-        if let Some(session_path) = Self::session_path(&manager)? {
-            let requested = Arc::clone(lock_requested);
-            connection
-                .add_match::<(), _>(
-                    MatchRule::new_signal("org.freedesktop.login1.Session", "Lock")
-                        .with_path(session_path),
-                    move |(), _, _| {
-                        requested.store(true, Ordering::Release);
-                        true
-                    },
-                )
-                .map_err(|error| lifecycle_error(&error))?;
-        }
-
-        Ok(Self {
+        let monitor = Self {
             connection,
             _delay_inhibitor: delay_inhibitor,
-        })
+            signal,
+            session_paths,
+            sessions_changed,
+        };
+        let manager = monitor.connection.with_proxy(
+            "org.freedesktop.login1",
+            "/org/freedesktop/login1",
+            LIFECYCLE_DBUS_TIMEOUT,
+        );
+        monitor.refresh_sessions(&manager)?;
+        Ok(monitor)
     }
 
-    /// Resolve the logind session whose `Lock` signal seals this vault.
-    ///
-    /// A session named through the environment must exist: the caller asked
-    /// for that one, so a lookup failure is a misconfiguration. Inferring the
-    /// session from this process ID may legitimately come up empty, because a
-    /// lingering systemd user service belongs to no logind session at all.
-    /// Sleep and shutdown monitoring above cover that deployment; there is no
-    /// screen to lock, so it degrades instead of refusing to serve.
-    fn session_path(manager: &Proxy<'_, &Connection>) -> VaultResult<Option<DbusPath<'static>>> {
-        let session_id = SESSION_ID_ENVIRONMENT.iter().find_map(|name| {
+    /// Track every logind session for this user, plus an explicitly selected
+    /// session. `LockedHint` is the actual lock state; `Lock` remains an eager
+    /// fallback for compositors that update the property late.
+    fn refresh_sessions(&self, manager: &Proxy<'_, &Connection>) -> VaultResult<()> {
+        type Session = (String, u32, String, String, DbusPath<'static>);
+        let (sessions,): (Vec<Session>,) = manager
+            .method_call("org.freedesktop.login1.Manager", "ListSessions", ())
+            .map_err(|error| lifecycle_error(&error))?;
+        let expected_uid = getuid().as_raw();
+        let mut paths: HashSet<String> = sessions
+            .into_iter()
+            .filter(|(_, uid, _, _, _)| *uid == expected_uid)
+            .map(|(_, _, _, _, path)| path.to_string())
+            .collect();
+
+        let explicit_session = SESSION_ID_ENVIRONMENT.iter().find_map(|name| {
             std::env::var(name)
                 .ok()
                 .filter(|session_id| !session_id.is_empty())
         });
-        if let Some(session_id) = session_id {
+        if let Some(session_id) = explicit_session {
             let (session_path,): (DbusPath<'static>,) = manager
                 .method_call(
                     "org.freedesktop.login1.Manager",
@@ -210,21 +399,79 @@ impl LinuxLifecycleMonitor {
                     (session_id,),
                 )
                 .map_err(|error| lifecycle_error(&error))?;
-            return Ok(Some(session_path));
+            paths.insert(session_path.to_string());
         }
-        let inferred: Result<(DbusPath<'static>,), dbus::Error> = manager.method_call(
-            "org.freedesktop.login1.Manager",
-            "GetSessionByPID",
-            (std::process::id(),),
-        );
-        Ok(inferred.ok().map(|(session_path,)| session_path))
+
+        for path in &paths {
+            let session = self.connection.with_proxy(
+                "org.freedesktop.login1",
+                path.as_str(),
+                LIFECYCLE_DBUS_TIMEOUT,
+            );
+            let locked: bool = session
+                .get("org.freedesktop.login1.Session", "LockedHint")
+                .map_err(|error| lifecycle_error(&error))?;
+            if locked {
+                self.signal.trigger();
+            }
+        }
+        *self
+            .session_paths
+            .lock()
+            .map_err(|_| VaultError::WorkerUnavailable)? = paths;
+        self.sessions_changed.store(false, Ordering::Release);
+        Ok(())
     }
 
-    fn process(&self) -> VaultResult<()> {
+    fn process(&self, timeout: Duration) -> VaultResult<()> {
         self.connection
-            .process(Duration::ZERO)
+            .process(timeout)
             .map(|_| ())
-            .map_err(|error| lifecycle_error(&error))
+            .map_err(|error| lifecycle_error(&error))?;
+        if self.sessions_changed.load(Ordering::Acquire) {
+            let manager = self.connection.with_proxy(
+                "org.freedesktop.login1",
+                "/org/freedesktop/login1",
+                LIFECYCLE_DBUS_TIMEOUT,
+            );
+            self.refresh_sessions(&manager)?;
+        }
+        Ok(())
+    }
+}
+
+fn message_path_is_tracked(path: Option<String>, paths: &Mutex<HashSet<String>>) -> bool {
+    let Some(path) = path else {
+        return false;
+    };
+    paths
+        .lock()
+        .map_or(true, |paths| paths.contains(path.as_str()))
+}
+
+fn locked_hint_is_true(changed: &PropMap) -> bool {
+    changed
+        .get("LockedHint")
+        .and_then(|value| value.0.as_i64())
+        .is_some_and(|value| value != 0)
+}
+
+fn abort_if_unsealed(signal: &LifecycleSignal) {
+    if signal.needs_emergency_exit() {
+        std::process::abort();
+    }
+}
+
+fn start_logind_deadline(signal: Arc<LifecycleSignal>) {
+    if std::thread::Builder::new()
+        .name("factorseal-logind-deadline".to_owned())
+        .spawn(move || {
+            std::thread::sleep(LOGIND_SEAL_DEADLINE);
+            abort_if_unsealed(&signal);
+        })
+        .is_err()
+    {
+        std::process::abort();
     }
 }
 
@@ -405,13 +652,20 @@ mod tests {
     }
 
     #[test]
-    fn session_lock_match_uses_an_exact_object_path() {
-        let path = DbusPath::from("/org/freedesktop/login1/session/_32").into_static();
-        let rule =
-            MatchRule::new_signal("org.freedesktop.login1.Session", "Lock").with_path(path.clone());
+    fn session_lock_events_are_filtered_to_tracked_user_sessions() {
+        let paths = Mutex::new(HashSet::from([
+            "/org/freedesktop/login1/session/_32".to_owned()
+        ]));
 
-        assert_eq!(rule.path, Some(path));
-        assert!(!rule.path_is_namespace);
+        assert!(message_path_is_tracked(
+            Some("/org/freedesktop/login1/session/_32".to_owned()),
+            &paths
+        ));
+        assert!(!message_path_is_tracked(
+            Some("/org/freedesktop/login1/session/_99".to_owned()),
+            &paths
+        ));
+        assert!(!message_path_is_tracked(None, &paths));
     }
 
     #[test]

--- a/src/vault/macos.rs
+++ b/src/vault/macos.rs
@@ -7,6 +7,7 @@
 
 #![allow(unsafe_code)]
 
+use std::ffi::{c_char, c_void};
 use std::fs::{self, File};
 use std::os::unix::fs::MetadataExt;
 #[cfg(test)]
@@ -16,6 +17,7 @@ use std::path::{Path, PathBuf};
 use std::ptr::NonNull;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::JoinHandle;
 use std::time::Duration;
 
 use block2::RcBlock;
@@ -27,7 +29,7 @@ use nix::unistd::getuid;
 use objc2::rc::Retained;
 use objc2::runtime::AnyObject;
 use objc2_app_kit::{
-    NSWorkspace, NSWorkspaceSessionDidResignActiveNotification,
+    NSWorkspace, NSWorkspaceDidWakeNotification, NSWorkspaceSessionDidResignActiveNotification,
     NSWorkspaceWillPowerOffNotification, NSWorkspaceWillSleepNotification,
 };
 use objc2_foundation::{NSDate, NSNotification, NSNotificationCenter, NSRunLoop};
@@ -40,7 +42,8 @@ use super::transport::unix_socket::{
 use super::transport::unix_time;
 use super::transport::{hash_file, hash_open_file, path_io_error};
 use super::{
-    CallerIdentity, CallerIdentityCache, CallerPlatform, VaultError, VaultResult, VaultService,
+    CallerIdentity, CallerIdentityCache, CallerPlatform, LifecycleSignal, VaultError, VaultResult,
+    VaultService,
 };
 #[cfg(test)]
 use super::{MacosVaultClient, VaultClient, VaultRequest};
@@ -55,8 +58,9 @@ pub struct MacosVaultOptions {
     /// Install SIGINT/SIGTERM handlers. Disable only when the embedding
     /// process supplies equivalent lifecycle handling.
     pub install_signal_handler: bool,
-    /// Require AppKit sleep, power-off, and session-switch notifications.
-    /// Disable only when the embedding process supplies equivalent hooks.
+    /// Require Core Graphics lock-state monitoring plus AppKit sleep, wake,
+    /// power-off, and session-switch notifications. Disable only when the
+    /// embedding process supplies equivalent hooks.
     pub install_lifecycle_monitor: bool,
 }
 
@@ -78,13 +82,40 @@ pub fn serve_macos_vault(
     service: &Arc<VaultService>,
     options: &MacosVaultOptions,
 ) -> VaultResult<()> {
+    let lifecycle = options
+        .install_lifecycle_monitor
+        .then(MacosVaultLifecycle::new);
+    if let Some(lifecycle) = lifecycle.as_ref() {
+        lifecycle.arm()?;
+    }
+    let result = serve_macos_vault_with_lifecycle(service, options, lifecycle.as_ref());
+    if let Some(lifecycle) = lifecycle.as_ref() {
+        lifecycle.disarm();
+    }
+    result
+}
+
+/// Serve with lifecycle observers established before vault unsealing.
+#[doc(hidden)]
+pub fn serve_macos_vault_with_lifecycle(
+    service: &Arc<VaultService>,
+    options: &MacosVaultOptions,
+    lifecycle_monitor: Option<&MacosVaultLifecycle>,
+) -> VaultResult<()> {
     validate_socket_options("macOS", &options.socket_path, options.poll_interval)?;
     let (listener, _socket_guard) = bind_listener(&options.socket_path)?;
 
     let stopping = Arc::new(AtomicBool::new(false));
-    let lifecycle_monitor = options
-        .install_lifecycle_monitor
-        .then(|| MacosLifecycleMonitor::new(service, &stopping));
+    if let Some(monitor) = lifecycle_monitor {
+        // Deliver notifications queued during hardware authorization before
+        // exposing the newly opened service.
+        monitor.process();
+        monitor.attach(service)?;
+    } else if options.install_lifecycle_monitor {
+        return Err(VaultError::Protocol(
+            "macOS lifecycle monitor was not prepared".to_owned(),
+        ));
+    }
     if options.install_signal_handler {
         install_shutdown_signal_handler(&stopping)?;
     }
@@ -103,7 +134,7 @@ pub fn serve_macos_vault(
             if let Some(monitor) = lifecycle_monitor.as_ref() {
                 monitor.process();
             }
-            Ok(false)
+            Ok(lifecycle_monitor.is_some_and(MacosVaultLifecycle::requested))
         },
         |stream| caller_identity(stream, &caller_cache),
     );
@@ -111,17 +142,23 @@ pub fn serve_macos_vault(
     served.and(sealed)
 }
 
-struct MacosLifecycleMonitor {
+#[doc(hidden)]
+pub struct MacosVaultLifecycle {
     notification_center: Retained<NSNotificationCenter>,
     observers: Vec<Retained<AnyObject>>,
     run_loop: Retained<NSRunLoop>,
+    signal: Arc<LifecycleSignal>,
+    poll_stopping: Arc<AtomicBool>,
+    poll_thread: Option<JoinHandle<()>>,
 }
 
-impl MacosLifecycleMonitor {
-    fn new(service: &Arc<VaultService>, stopping: &Arc<AtomicBool>) -> Self {
+impl MacosVaultLifecycle {
+    #[must_use]
+    pub fn new() -> Self {
         let workspace = NSWorkspace::sharedWorkspace();
         let notification_center = workspace.notificationCenter();
-        let mut observers = Vec::with_capacity(3);
+        let signal = Arc::new(LifecycleSignal::new());
+        let mut observers = Vec::with_capacity(4);
 
         // SAFETY: These are AppKit-owned static notification names, and the
         // block's NonNull<NSNotification> argument exactly matches the
@@ -131,16 +168,20 @@ impl MacosLifecycleMonitor {
                 NSWorkspaceWillSleepNotification,
                 NSWorkspaceWillPowerOffNotification,
                 NSWorkspaceSessionDidResignActiveNotification,
+                // Resume is a fail-closed fallback if the pre-sleep edge was
+                // lost while AppKit's run loop was unavailable.
+                NSWorkspaceDidWakeNotification,
             ]
         } {
-            let lifecycle_service = Arc::clone(service);
-            let lifecycle_stopping = Arc::clone(stopping);
+            let lifecycle_signal = Arc::clone(&signal);
             let block = RcBlock::new(move |_notification: NonNull<NSNotification>| {
-                // Lock synchronously before returning from the pre-sleep or
-                // session callback; the event-loop poll is not the security
-                // boundary for zeroizing hardware-unwrapped keys.
-                let _ = lifecycle_service.seal();
-                lifecycle_stopping.store(true, Ordering::Release);
+                lifecycle_signal.trigger();
+                if lifecycle_signal.needs_emergency_exit() {
+                    // AppKit provides no suspend-delay token. Termination is
+                    // the only fail-closed path if sealing cannot complete in
+                    // the notification callback.
+                    std::process::abort();
+                }
             });
             let observer = unsafe {
                 notification_center.addObserverForName_object_queue_usingBlock(
@@ -153,26 +194,128 @@ impl MacosLifecycleMonitor {
             observers.push(observer.into());
         }
 
-        Self {
+        let mut lifecycle = Self {
             notification_center,
             observers,
             run_loop: NSRunLoop::currentRunLoop(),
+            signal: Arc::clone(&signal),
+            poll_stopping: Arc::new(AtomicBool::new(false)),
+            poll_thread: None,
+        };
+        if macos_screen_is_locked().unwrap_or(true) {
+            lifecycle.signal.trigger();
         }
+        let poll_stopping = Arc::clone(&lifecycle.poll_stopping);
+        let poll_signal = signal;
+        let poll_thread = std::thread::Builder::new()
+            .name("factorseal-macos-lock-state".to_owned())
+            .spawn(move || {
+                while !poll_stopping.load(Ordering::Acquire) {
+                    if macos_screen_is_locked().unwrap_or(true) {
+                        poll_signal.trigger();
+                        if poll_signal.needs_emergency_exit() {
+                            std::process::abort();
+                        }
+                        break;
+                    }
+                    std::thread::sleep(DEFAULT_POLL_INTERVAL);
+                }
+            })
+            .unwrap_or_else(|_| std::process::abort());
+        lifecycle.poll_thread = Some(poll_thread);
+        lifecycle
     }
 
     fn process(&self) {
         self.run_loop
             .runUntilDate(&NSDate::dateWithTimeIntervalSinceNow(0.0));
+        if macos_screen_is_locked().unwrap_or(true) {
+            self.signal.trigger();
+        }
+    }
+
+    pub fn arm(&self) -> VaultResult<()> {
+        self.signal.arm()
+    }
+
+    pub fn disarm(&self) {
+        self.signal.disarm();
+    }
+
+    #[must_use]
+    pub fn requested(&self) -> bool {
+        self.signal.requested()
+    }
+
+    fn attach(&self, service: &Arc<VaultService>) -> VaultResult<()> {
+        self.signal.attach(service)
     }
 }
 
-impl Drop for MacosLifecycleMonitor {
+impl Default for MacosVaultLifecycle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for MacosVaultLifecycle {
     fn drop(&mut self) {
+        self.poll_stopping.store(true, Ordering::Release);
+        if let Some(thread) = self.poll_thread.take() {
+            let _ = thread.join();
+        }
         for observer in &self.observers {
             // SAFETY: Each retained token was returned by this exact
             // notification center's block-observer registration method.
             unsafe { self.notification_center.removeObserver(observer) };
         }
+    }
+}
+
+// Core Graphics exposes the current login-session dictionary but does not
+// provide a typed Rust binding for its screen-lock entry. Keep the small,
+// read-only Core Foundation bridge here beside the lifecycle integration.
+#[link(name = "CoreGraphics", kind = "framework")]
+unsafe extern "C" {
+    fn CGSessionCopyCurrentDictionary() -> *const c_void;
+}
+
+#[link(name = "CoreFoundation", kind = "framework")]
+unsafe extern "C" {
+    fn CFStringCreateWithCString(
+        allocator: *const c_void,
+        bytes: *const c_char,
+        encoding: u32,
+    ) -> *const c_void;
+    fn CFDictionaryGetValue(dictionary: *const c_void, key: *const c_void) -> *const c_void;
+    fn CFGetTypeID(value: *const c_void) -> usize;
+    fn CFBooleanGetTypeID() -> usize;
+    fn CFBooleanGetValue(value: *const c_void) -> u8;
+    fn CFRelease(value: *const c_void);
+}
+
+fn macos_screen_is_locked() -> Option<bool> {
+    const UTF8: u32 = 0x0800_0100;
+    const KEY: &[u8] = b"CGSSessionScreenIsLocked\0";
+    // SAFETY: Both Copy/Create functions return owned CF objects. The key is
+    // NUL-terminated UTF-8, dictionary lookup does not retain, and the value's
+    // type is checked before calling CFBooleanGetValue.
+    unsafe {
+        let dictionary = CGSessionCopyCurrentDictionary();
+        if dictionary.is_null() {
+            return None;
+        }
+        let key = CFStringCreateWithCString(std::ptr::null(), KEY.as_ptr().cast::<c_char>(), UTF8);
+        if key.is_null() {
+            CFRelease(dictionary);
+            return None;
+        }
+        let value = CFDictionaryGetValue(dictionary, key);
+        let locked = (!value.is_null() && CFGetTypeID(value) == CFBooleanGetTypeID())
+            .then(|| CFBooleanGetValue(value) != 0);
+        CFRelease(key);
+        CFRelease(dictionary);
+        locked.or(Some(false))
     }
 }
 
@@ -352,8 +495,9 @@ mod tests {
         let now = unix_time().unwrap();
         let service =
             Arc::new(VaultService::new(store, now, UnsealLeasePolicy::default()).unwrap());
-        let stopping = Arc::new(AtomicBool::new(false));
-        let monitor = MacosLifecycleMonitor::new(&service, &stopping);
+        let monitor = MacosVaultLifecycle::new();
+        monitor.arm().unwrap();
+        monitor.attach(&service).unwrap();
         // SAFETY: This posts the same AppKit-owned notification name used by
         // registration and carries no dynamically typed object payload.
         unsafe {
@@ -361,7 +505,7 @@ mod tests {
                 .notification_center
                 .postNotificationName_object(NSWorkspaceWillSleepNotification, None);
         }
-        assert!(stopping.load(Ordering::Acquire));
+        assert!(monitor.requested());
         assert!(service.expire_if_needed(now).unwrap());
     }
 

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -51,7 +51,17 @@ use std::fmt;
     feature = "vault",
     any(target_os = "linux", target_os = "macos", target_os = "windows")
 ))]
+use std::sync::Arc;
+#[cfg(all(
+    feature = "vault",
+    any(target_os = "linux", target_os = "macos", target_os = "windows")
+))]
 use std::sync::Mutex;
+#[cfg(all(
+    feature = "vault",
+    any(target_os = "linux", target_os = "macos", target_os = "windows")
+))]
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use serde::{Deserialize, Serialize};
@@ -83,9 +93,15 @@ pub use seal::{
 pub(crate) use store::VaultStore;
 
 #[cfg(all(feature = "vault", target_os = "linux"))]
-pub use linux::{LinuxVaultOptions, linux_caller_identity_for_executable, serve_linux_vault};
+pub use linux::{
+    LinuxVaultLifecycle, LinuxVaultOptions, linux_caller_identity_for_executable,
+    serve_linux_vault, serve_linux_vault_with_lifecycle,
+};
 #[cfg(all(feature = "vault", target_os = "macos"))]
-pub use macos::{MacosVaultOptions, macos_caller_identity_for_executable, serve_macos_vault};
+pub use macos::{
+    MacosVaultLifecycle, MacosVaultOptions, macos_caller_identity_for_executable,
+    serve_macos_vault, serve_macos_vault_with_lifecycle,
+};
 
 // Linux and macOS share one Unix socket client; each target names it after
 // the transport it talks to.
@@ -96,7 +112,8 @@ pub use unix_client::UnixVaultClient as MacosVaultClient;
 
 #[cfg(all(feature = "vault", target_os = "windows"))]
 pub use windows::{
-    WindowsVaultOptions, serve_windows_vault, windows_caller_identity_for_executable,
+    WindowsVaultLifecycle, WindowsVaultOptions, serve_windows_vault,
+    serve_windows_vault_with_lifecycle, windows_caller_identity_for_executable,
 };
 #[cfg(all(feature = "vault-client", target_os = "windows"))]
 pub use windows_client::{WindowsVaultClient, default_windows_pipe_name};
@@ -150,6 +167,111 @@ impl CallerIdentityCache {
         }
         entries.insert(key, identity.clone());
         Ok(identity)
+    }
+}
+
+/// Latches native lifecycle events before hardware-unwrapped keys enter
+/// memory, then connects those events to the live service once it exists.
+///
+/// Registration and unsealing deliberately happen in that order. If lock or
+/// suspend arrives during native authorization or database opening, attaching
+/// the service observes the latch and seals it before accepting any client.
+#[cfg(all(
+    feature = "vault",
+    any(target_os = "linux", target_os = "macos", target_os = "windows")
+))]
+struct LifecycleSignal {
+    requested: AtomicBool,
+    armed: AtomicBool,
+    safe: AtomicBool,
+    service: Mutex<Option<Arc<VaultService>>>,
+}
+
+#[cfg(all(
+    feature = "vault",
+    any(target_os = "linux", target_os = "macos", target_os = "windows")
+))]
+impl LifecycleSignal {
+    fn new() -> Self {
+        Self {
+            requested: AtomicBool::new(false),
+            armed: AtomicBool::new(false),
+            safe: AtomicBool::new(true),
+            service: Mutex::new(None),
+        }
+    }
+
+    fn arm(&self) -> VaultResult<()> {
+        if self.requested.load(Ordering::Acquire) {
+            return Err(VaultError::NativeAuthorization(
+                NativeAuthorizationError::SessionLocked,
+            ));
+        }
+        self.safe.store(false, Ordering::Release);
+        self.armed.store(true, Ordering::Release);
+        // Close the check/arm race: a callback that ran between the first
+        // load and `armed.store` leaves the latch set and must abort unseal.
+        if self.requested.load(Ordering::Acquire) {
+            self.disarm();
+            return Err(VaultError::NativeAuthorization(
+                NativeAuthorizationError::SessionLocked,
+            ));
+        }
+        Ok(())
+    }
+
+    fn attach(&self, service: &Arc<VaultService>) -> VaultResult<()> {
+        let mut attached = self
+            .service
+            .lock()
+            .map_err(|_| VaultError::WorkerUnavailable)?;
+        *attached = Some(Arc::clone(service));
+        if self.requested.load(Ordering::Acquire) {
+            service.seal()?;
+            self.safe
+                .store(service.is_seal_complete(), Ordering::Release);
+        }
+        Ok(())
+    }
+
+    fn trigger(&self) {
+        self.requested.store(true, Ordering::Release);
+        let service = self
+            .service
+            .lock()
+            .ok()
+            .and_then(|service| service.as_ref().map(Arc::clone));
+        if let Some(service) = service {
+            let _ = service.seal();
+            self.safe
+                .store(service.is_seal_complete(), Ordering::Release);
+        }
+    }
+
+    fn requested(&self) -> bool {
+        self.requested.load(Ordering::Acquire)
+    }
+
+    fn needs_emergency_exit(&self) -> bool {
+        self.armed.load(Ordering::Acquire) && !self.safe.load(Ordering::Acquire)
+    }
+
+    fn disarm(&self) {
+        let Ok(mut service) = self.service.lock() else {
+            return;
+        };
+        // A lifecycle callback marks the store sealed before it finishes
+        // joining the key-bearing worker. Keep emergency deadlines effective
+        // until that teardown has actually completed.
+        if service
+            .as_ref()
+            .is_some_and(|service| !service.is_seal_complete())
+        {
+            return;
+        }
+        self.armed.store(false, Ordering::Release);
+        self.safe.store(true, Ordering::Release);
+        *service = None;
     }
 }
 
@@ -667,5 +789,36 @@ mod tests {
         assert_ne!(plain.storage_key(), field.storage_key());
         assert!(!field.storage_key().contains("production"));
         assert!(!field.storage_key().contains("password"));
+    }
+
+    #[cfg(all(
+        feature = "vault",
+        any(target_os = "linux", target_os = "macos", target_os = "windows")
+    ))]
+    #[test]
+    fn lifecycle_events_latch_before_a_service_is_attached() {
+        let signal = LifecycleSignal::new();
+        signal.arm().unwrap();
+        signal.trigger();
+
+        assert!(signal.requested());
+        assert!(signal.needs_emergency_exit());
+    }
+
+    #[cfg(all(
+        feature = "vault",
+        any(target_os = "linux", target_os = "macos", target_os = "windows")
+    ))]
+    #[test]
+    fn an_already_locked_session_refuses_to_arm() {
+        let signal = LifecycleSignal::new();
+        signal.trigger();
+
+        assert!(matches!(
+            signal.arm(),
+            Err(VaultError::NativeAuthorization(
+                NativeAuthorizationError::SessionLocked
+            ))
+        ));
     }
 }

--- a/src/vault/protocol/service.rs
+++ b/src/vault/protocol/service.rs
@@ -148,6 +148,10 @@ impl VaultService {
         Ok(())
     }
 
+    pub(crate) fn is_seal_complete(&self) -> bool {
+        self.state.is_seal_complete()
+    }
+
     fn handle_inner(
         &self,
         caller: &CallerIdentity,

--- a/src/vault/protocol/service/state.rs
+++ b/src/vault/protocol/service/state.rs
@@ -62,6 +62,10 @@ impl ServiceState {
         self.seal_handle.is_sealed()
     }
 
+    pub(super) fn is_seal_complete(&self) -> bool {
+        self.seal_handle.is_shutdown_complete()
+    }
+
     pub(super) fn seal(&self) {
         self.seal_handle.seal();
         self.approval_changed.notify_all();

--- a/src/vault/store.rs
+++ b/src/vault/store.rs
@@ -54,6 +54,11 @@ impl VaultStore {
         self.control.is_sealed()
     }
 
+    #[must_use]
+    pub(crate) fn is_shutdown_complete(&self) -> bool {
+        self.control.is_shutdown_complete()
+    }
+
     /// Delete one secret idempotently.
     pub(crate) fn delete(
         &self,

--- a/src/vault/store/worker.rs
+++ b/src/vault/store/worker.rs
@@ -42,6 +42,7 @@ pub(super) struct WorkerControl {
     pub(super) sender: mpsc::SyncSender<Command>,
     join: Mutex<Option<JoinHandle<()>>>,
     sealed: AtomicBool,
+    shutdown_complete: AtomicBool,
 }
 
 impl WorkerControl {
@@ -58,6 +59,7 @@ impl WorkerControl {
                 sender,
                 join: Mutex::new(Some(join)),
                 sealed: AtomicBool::new(false),
+                shutdown_complete: AtomicBool::new(false),
             }),
             Ok(Err(error)) => {
                 let _ = join.join();
@@ -71,19 +73,28 @@ impl WorkerControl {
     }
 
     pub(super) fn shutdown(&self) {
-        if self.sealed.swap(true, Ordering::AcqRel) {
-            return;
+        if !self.sealed.swap(true, Ordering::AcqRel) {
+            let _ = self.sender.send(Command::Shutdown);
         }
-        let _ = self.sender.send(Command::Shutdown);
-        if let Ok(mut join) = self.join.lock()
-            && let Some(handle) = join.take()
-        {
+        let Ok(mut join) = self.join.lock() else {
+            return;
+        };
+        if let Some(handle) = join.take() {
             let _ = handle.join();
         }
+        // Concurrent callers must not observe sealing as complete until the
+        // caller that took the join handle has finished waiting for it. The
+        // join mutex provides that hand-off even when this caller did not
+        // initiate shutdown.
+        self.shutdown_complete.store(true, Ordering::Release);
     }
 
     pub(super) fn is_sealed(&self) -> bool {
         self.sealed.load(Ordering::Acquire)
+    }
+
+    pub(super) fn is_shutdown_complete(&self) -> bool {
+        self.shutdown_complete.load(Ordering::Acquire)
     }
 }
 

--- a/src/vault/windows.rs
+++ b/src/vault/windows.rs
@@ -30,18 +30,20 @@ use windows::Win32::System::Power::{
     HPOWERNOTIFY, RegisterSuspendResumeNotification, UnregisterSuspendResumeNotification,
 };
 use windows::Win32::System::RemoteDesktop::{
-    NOTIFY_FOR_THIS_SESSION, WTSRegisterSessionNotification, WTSUnRegisterSessionNotification,
+    NOTIFY_FOR_THIS_SESSION, WTS_CURRENT_SESSION, WTS_SESSIONSTATE_LOCK, WTS_SESSIONSTATE_UNLOCK,
+    WTSFreeMemory, WTSINFOEXW, WTSQuerySessionInformationW, WTSRegisterSessionNotification,
+    WTSSessionInfoEx, WTSUnRegisterSessionNotification,
 };
 use windows::Win32::System::Threading::{GetCurrentThread, GetCurrentThreadId, OpenThreadToken};
 use windows::Win32::UI::WindowsAndMessaging::{
     CREATESTRUCTW, DEVICE_NOTIFY_WINDOW_HANDLE, DefWindowProcW, DestroyWindow, DispatchMessageW,
-    GWLP_USERDATA, GetMessageW, GetWindowLongPtrW, MSG, PBT_APMSUSPEND, PostThreadMessageW,
-    RegisterClassW, SetWindowLongPtrW, TranslateMessage, UnregisterClassW, WINDOW_EX_STYLE,
-    WINDOW_STYLE, WM_ENDSESSION, WM_NCCREATE, WM_POWERBROADCAST, WM_QUERYENDSESSION, WM_QUIT,
-    WM_WTSSESSION_CHANGE, WNDCLASSW, WTS_CONSOLE_DISCONNECT, WTS_REMOTE_DISCONNECT,
-    WTS_SESSION_LOCK, WTS_SESSION_LOGOFF,
+    GWLP_USERDATA, GetMessageW, GetWindowLongPtrW, MSG, PBT_APMRESUMEAUTOMATIC,
+    PBT_APMRESUMESUSPEND, PBT_APMSUSPEND, PostThreadMessageW, RegisterClassW, SetWindowLongPtrW,
+    TranslateMessage, UnregisterClassW, WINDOW_EX_STYLE, WINDOW_STYLE, WM_ENDSESSION, WM_NCCREATE,
+    WM_POWERBROADCAST, WM_QUERYENDSESSION, WM_QUIT, WM_WTSSESSION_CHANGE, WNDCLASSW,
+    WTS_CONSOLE_DISCONNECT, WTS_REMOTE_DISCONNECT, WTS_SESSION_LOCK, WTS_SESSION_LOGOFF,
 };
-use windows::core::PCWSTR;
+use windows::core::{PCWSTR, PWSTR};
 
 use super::transport::{
     IPC_FRAME_IO_TIMEOUT, IoBudget, MAX_ACTIVE_CONNECTIONS, hash_file, hash_open_file,
@@ -49,13 +51,14 @@ use super::transport::{
 };
 use super::windows_client::validate_pipe_name;
 use super::{
-    CallerIdentity, CallerIdentityCache, CallerPlatform, VaultError, VaultRequest, VaultResult,
-    VaultService,
+    CallerIdentity, CallerIdentityCache, CallerPlatform, LifecycleSignal, VaultError, VaultRequest,
+    VaultResult, VaultService,
 };
 #[cfg(test)]
 use super::{VaultClient, WindowsVaultClient};
 
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const WINDOWS_SUSPEND_SEAL_DEADLINE: Duration = Duration::from_millis(1_500);
 
 type BytePipe = DuplexPipeStream<pipe_mode::Bytes>;
 type ByteListener = PipeListener<pipe_mode::Bytes, pipe_mode::Bytes>;
@@ -68,8 +71,9 @@ pub struct WindowsVaultOptions {
     /// Install console termination handlers. Disable only when an embedding
     /// process supplies equivalent lifecycle handling.
     pub install_signal_handler: bool,
-    /// Require native suspend, shutdown, logout, disconnect, and session-lock
-    /// notifications. Disable only when an embedding process supplies them.
+    /// Require native suspend/resume, shutdown, logout, disconnect, and
+    /// session-lock notifications. Disable only when an embedding process
+    /// supplies them.
     pub install_lifecycle_monitor: bool,
 }
 
@@ -94,6 +98,27 @@ pub fn serve_windows_vault(
     service: &Arc<VaultService>,
     options: &WindowsVaultOptions,
 ) -> VaultResult<()> {
+    let lifecycle = options
+        .install_lifecycle_monitor
+        .then(WindowsVaultLifecycle::new)
+        .transpose()?;
+    if let Some(lifecycle) = lifecycle.as_ref() {
+        lifecycle.arm()?;
+    }
+    let result = serve_windows_vault_with_lifecycle(service, options, lifecycle.as_ref());
+    if let Some(lifecycle) = lifecycle.as_ref() {
+        lifecycle.disarm();
+    }
+    result
+}
+
+/// Serve with native lifecycle notifications registered before unsealing.
+#[doc(hidden)]
+pub fn serve_windows_vault_with_lifecycle(
+    service: &Arc<VaultService>,
+    options: &WindowsVaultOptions,
+    lifecycle_monitor: Option<&WindowsVaultLifecycle>,
+) -> VaultResult<()> {
     validate_options(options)?;
     let security_descriptor = same_user_security_descriptor()?;
     let listener = PipeListenerOptions::new()
@@ -104,11 +129,17 @@ pub fn serve_windows_vault(
         .create_duplex::<pipe_mode::Bytes>()
         .map_err(|error| io_error("create named pipe", &error))?;
 
-    let stopping = Arc::new(AtomicBool::new(false));
-    let _lifecycle_monitor = options
-        .install_lifecycle_monitor
-        .then(|| WindowsLifecycleMonitor::new(Arc::clone(service), Arc::clone(&stopping)))
-        .transpose()?;
+    let stopping = lifecycle_monitor.map_or_else(
+        || Arc::new(AtomicBool::new(false)),
+        |monitor| Arc::clone(&monitor.stopping),
+    );
+    if let Some(monitor) = lifecycle_monitor {
+        monitor.attach(service)?;
+    } else if options.install_lifecycle_monitor {
+        return Err(VaultError::Protocol(
+            "Windows lifecycle monitor was not prepared".to_owned(),
+        ));
+    }
     if options.install_signal_handler {
         let signal_stopping = Arc::clone(&stopping);
         ctrlc::set_handler(move || signal_stopping.store(true, Ordering::Release)).map_err(
@@ -181,17 +212,24 @@ impl Drop for ActiveConnection<'_> {
     }
 }
 
-struct WindowsLifecycleMonitor {
+#[doc(hidden)]
+pub struct WindowsVaultLifecycle {
     thread_id: u32,
     thread: Option<JoinHandle<()>>,
+    signal: Arc<LifecycleSignal>,
+    stopping: Arc<AtomicBool>,
 }
 
-impl WindowsLifecycleMonitor {
-    fn new(service: Arc<VaultService>, stopping: Arc<AtomicBool>) -> VaultResult<Self> {
+impl WindowsVaultLifecycle {
+    pub fn new() -> VaultResult<Self> {
         let (ready_sender, ready_receiver) = sync_channel(1);
+        let signal = Arc::new(LifecycleSignal::new());
+        let stopping = Arc::new(AtomicBool::new(false));
+        let thread_signal = Arc::clone(&signal);
+        let thread_stopping = Arc::clone(&stopping);
         let thread = std::thread::Builder::new()
             .name("factorseal-windows-lifecycle".to_owned())
-            .spawn(move || lifecycle_message_loop(service, stopping, &ready_sender))
+            .spawn(move || lifecycle_message_loop(&thread_signal, thread_stopping, &ready_sender))
             .map_err(|error| {
                 VaultError::Protocol(format!("could not start lifecycle monitor: {error}"))
             })?;
@@ -204,11 +242,30 @@ impl WindowsLifecycleMonitor {
         Ok(Self {
             thread_id,
             thread: Some(thread),
+            signal,
+            stopping,
         })
+    }
+
+    pub fn arm(&self) -> VaultResult<()> {
+        self.signal.arm()
+    }
+
+    pub fn disarm(&self) {
+        self.signal.disarm();
+    }
+
+    #[must_use]
+    pub fn requested(&self) -> bool {
+        self.signal.requested()
+    }
+
+    fn attach(&self, service: &Arc<VaultService>) -> VaultResult<()> {
+        self.signal.attach(service)
     }
 }
 
-impl Drop for WindowsLifecycleMonitor {
+impl Drop for WindowsVaultLifecycle {
     fn drop(&mut self) {
         // SAFETY: `thread_id` is reported only after the lifecycle thread has
         // created its message queue. WM_QUIT owns no pointer payload.
@@ -220,12 +277,12 @@ impl Drop for WindowsLifecycleMonitor {
 }
 
 struct WindowsLifecycleContext {
-    service: Arc<VaultService>,
+    signal: Arc<LifecycleSignal>,
     stopping: Arc<AtomicBool>,
 }
 
 fn lifecycle_message_loop(
-    service: Arc<VaultService>,
+    signal: &Arc<LifecycleSignal>,
     stopping: Arc<AtomicBool>,
     ready: &SyncSender<Result<u32, String>>,
 ) {
@@ -263,7 +320,10 @@ fn lifecycle_message_loop(
             return;
         }
 
-        let context = Box::new(WindowsLifecycleContext { service, stopping });
+        let context = Box::new(WindowsLifecycleContext {
+            signal: Arc::clone(signal),
+            stopping,
+        });
         let context_ptr = Box::into_raw(context);
         let window = match windows::Win32::UI::WindowsAndMessaging::CreateWindowExW(
             WINDOW_EX_STYLE(0),
@@ -309,20 +369,78 @@ fn lifecycle_message_loop(
             }
         };
 
+        match current_session_is_locked() {
+            Ok(true) => signal.trigger(),
+            Ok(false) => {}
+            Err(error) => {
+                cleanup_lifecycle_window(window, Some(power), context_ptr, &class_name, instance);
+                let _ = ready.send(Err(error));
+                return;
+            }
+        }
+
         if ready.send(Ok(GetCurrentThreadId())).is_err() {
             cleanup_lifecycle_window(window, Some(power), context_ptr, &class_name, instance);
             return;
         }
-        let mut message = MSG::default();
-        loop {
-            let result = GetMessageW(&raw mut message, None, 0, 0).0;
-            if result <= 0 {
-                break;
-            }
-            let _ = TranslateMessage(&raw const message);
-            DispatchMessageW(&raw const message);
-        }
+        dispatch_lifecycle_messages();
         cleanup_lifecycle_window(window, Some(power), context_ptr, &class_name, instance);
+    }
+}
+
+unsafe fn dispatch_lifecycle_messages() {
+    let mut message = MSG::default();
+    loop {
+        let result = unsafe { GetMessageW(&raw mut message, None, 0, 0) }.0;
+        if result <= 0 {
+            break;
+        }
+        let _ = unsafe { TranslateMessage(&raw const message) };
+        unsafe { DispatchMessageW(&raw const message) };
+    }
+}
+
+unsafe fn current_session_is_locked() -> Result<bool, String> {
+    let mut buffer = PWSTR::null();
+    let mut bytes = 0;
+    // SAFETY: WTS allocates `buffer` on success and reports its byte length.
+    unsafe {
+        WTSQuerySessionInformationW(
+            None,
+            WTS_CURRENT_SESSION,
+            WTSSessionInfoEx,
+            &raw mut buffer,
+            &raw mut bytes,
+        )
+    }
+    .map_err(|error| format!("could not read the current Windows session state: {error}"))?;
+    let expected_bytes = u32::try_from(std::mem::size_of::<WTSINFOEXW>())
+        .map_err(|_| "Windows session-state structure is too large".to_owned())?;
+    if buffer.is_null() || bytes < expected_bytes {
+        if !buffer.is_null() {
+            unsafe { WTSFreeMemory(buffer.as_ptr().cast()) };
+        }
+        return Err("Windows returned an invalid current-session state".to_owned());
+    }
+    // SAFETY: The successful query returned at least one complete WTSINFOEXW.
+    let information = unsafe { buffer.as_ptr().cast::<WTSINFOEXW>().read_unaligned() };
+    unsafe { WTSFreeMemory(buffer.as_ptr().cast()) };
+    if information.Level != 1 {
+        return Err(format!(
+            "Windows returned unsupported session-state level {}",
+            information.Level
+        ));
+    }
+    // SAFETY: Level 1 selects the sole WTSInfoExLevel1 union member.
+    let flags = unsafe { information.Data.WTSInfoExLevel1.SessionFlags };
+    if flags == WTS_SESSIONSTATE_LOCK.cast_signed() {
+        Ok(true)
+    } else if flags == WTS_SESSIONSTATE_UNLOCK.cast_signed() {
+        Ok(false)
+    } else {
+        Err(format!(
+            "Windows returned unknown current-session state {flags}"
+        ))
     }
 }
 
@@ -364,7 +482,14 @@ unsafe extern "system" fn lifecycle_window_proc(
     if !context.is_null() && lifecycle_message_requires_lock(message, wparam.0) {
         // SAFETY: The pointer remains owned until after DestroyWindow returns.
         let context = unsafe { &*context };
-        let _ = context.service.seal();
+        let suspend = message == WM_POWERBROADCAST && wparam.0 == PBT_APMSUSPEND as usize;
+        if suspend {
+            start_suspend_deadline(Arc::clone(&context.signal));
+        }
+        context.signal.trigger();
+        if !suspend && context.signal.needs_emergency_exit() {
+            std::process::abort();
+        }
         context.stopping.store(true, Ordering::Release);
     }
     // SAFETY: Messages not otherwise consumed retain default Win32 behavior.
@@ -373,7 +498,11 @@ unsafe extern "system" fn lifecycle_window_proc(
 
 const fn lifecycle_message_requires_lock(message: u32, parameter: usize) -> bool {
     match message {
-        WM_POWERBROADCAST => parameter == PBT_APMSUSPEND as usize,
+        WM_POWERBROADCAST => {
+            parameter == PBT_APMSUSPEND as usize
+                || parameter == PBT_APMRESUMEAUTOMATIC as usize
+                || parameter == PBT_APMRESUMESUSPEND as usize
+        }
         WM_QUERYENDSESSION => true,
         WM_ENDSESSION => parameter != 0,
         WM_WTSSESSION_CHANGE => {
@@ -383,6 +512,24 @@ const fn lifecycle_message_requires_lock(message: u32, parameter: usize) -> bool
                 || parameter == WTS_REMOTE_DISCONNECT as usize
         }
         _ => false,
+    }
+}
+
+fn start_suspend_deadline(signal: Arc<LifecycleSignal>) {
+    if std::thread::Builder::new()
+        .name("factorseal-suspend-deadline".to_owned())
+        .spawn(move || {
+            std::thread::sleep(WINDOWS_SUSPEND_SEAL_DEADLINE);
+            if signal.needs_emergency_exit() {
+                // Windows allows only a very short suspend callback. If the
+                // store cannot finish synchronously, terminating the process
+                // drops all remaining key-bearing memory before suspend.
+                std::process::abort();
+            }
+        })
+        .is_err()
+    {
+        std::process::abort();
     }
 }
 
@@ -594,9 +741,10 @@ mod tests {
         let service = Arc::new(
             VaultService::new(store, unix_time().unwrap(), UnsealLeasePolicy::default()).unwrap(),
         );
-        let stopping = Arc::new(AtomicBool::new(false));
-        let monitor = WindowsLifecycleMonitor::new(service, Arc::clone(&stopping)).unwrap();
-        assert!(!stopping.load(Ordering::Acquire));
+        let monitor = WindowsVaultLifecycle::new().unwrap();
+        monitor.arm().unwrap();
+        monitor.attach(&service).unwrap();
+        assert!(!monitor.requested());
         drop(monitor);
     }
 

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -34,6 +34,8 @@ fn every_physical_runner_emits_the_same_core_evidence_contract() {
             "test.hardware_self_test",
             "test.initial_unseal",
             "test.ipc_round_trip",
+            "test.screen_lock_seal",
+            "test.suspend_seal",
             "test.lifecycle_seal",
             "test.sealed_read_denied",
             "test.reunseal_recovery",
@@ -44,6 +46,24 @@ fn every_physical_runner_emits_the_same_core_evidence_contract() {
             assert!(source.contains(marker), "{name} does not emit `{marker}`");
         }
     }
+}
+
+#[test]
+fn guided_lifecycle_runs_cover_screen_lock_and_suspend_independently() {
+    let linux = runner("linux.sh");
+    assert!(linux.contains("loginctl lock-session"));
+    assert!(linux.contains("systemctl suspend"));
+    assert!(linux.contains("acceptance-after-lock.log"));
+
+    let macos = runner("macos.sh");
+    assert!(macos.contains("lifecycle_event=all"));
+    assert!(macos.contains("lifecycle_events=\"lock sleep\""));
+    assert!(macos.contains("acceptance-after-$event.log"));
+
+    let windows = runner("windows.ps1");
+    assert!(windows.contains("Win+L"));
+    assert!(windows.contains("Start > Power > Sleep"));
+    assert!(windows.contains("acceptance-after-lock.log"));
 }
 
 /// The self-test only means something on real hardware, so CI can check that


### PR DESCRIPTION
## Summary

- arm native lifecycle monitoring before vault unsealing and latch events during authorization
- seal on screen lock and suspend across Linux, macOS, and Windows with fail-closed deadlines
- track completed store shutdown before releasing suspend handling
- expand physical acceptance runners to test screen lock and suspend independently with a recovery unseal between them

## Platform behavior

- Linux: monitor LockedHint across all user logind sessions on a dedicated thread and hold a delay inhibitor for sleep/shutdown
- macOS: poll Core Graphics session lock state and observe AppKit sleep, wake, power-off, and session changes
- Windows: query initial WTS lock state, handle WTS/power messages, and enforce the suspend callback deadline

## Verification

- cargo test --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc --all-features --no-deps
- cargo test --test acceptance
- cargo test --test packaging
- shellcheck acceptance/linux.sh acceptance/macos.sh
- sh -n acceptance/linux.sh acceptance/macos.sh
- cargo fmt --all -- --check
- git diff --check

Native macOS and Windows lifecycle execution remains part of the opt-in physical acceptance run.