### PR TITLE
Add XDG Secret portal backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to FactorSeal will be documented in this file.
 
 ## Unreleased
 
+- Add an opt-in `org.freedesktop.impl.portal.Secret` backend on Linux, with a
+  durable random master key isolated per portal-authenticated application ID,
+  D-Bus activation metadata, and fail-closed behavior while the vault is
+  sealed.
 - Replace XChaCha20-Poly1305 vault envelopes with version-3 AES-256-GCM
   envelopes and add persisted `default` and `fips` vault profiles. The default
   password KDF is memory-hard Argon2id; `factorseal init --fips` selects

--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ For the full storage and verification invariants, see
 | SecretSpec provider | `secretspec-provider-cache` | project name | disposable, optionally expiring |
 | Rust `Keyring` | `local-keyring` | caller namespace | durable |
 | Linux Secret Service | `linux-secret-service` | service namespace | durable |
+| XDG Secret portal | `linux-secret-portal` | portal namespace | durable |
 | Grants | `authorization` | authorization namespace | durable |
 
 Each row is a separate authorization domain. In particular, a provider-cache
@@ -390,6 +391,20 @@ session bus and back its default collection with the same encrypted vault. Do
 not run another provider that owns that bus name, such as GNOME Keyring or oo7,
 at the same time. macOS Keychain and Windows Credential Manager remain separate
 platform interfaces.
+
+### XDG Secret portal
+
+On Linux, Factorseal also provides an opt-in
+`org.freedesktop.impl.portal.Secret` backend for sandboxed applications. The
+desktop's `xdg-desktop-portal` frontend supplies the authenticated application
+ID; Factorseal returns one stable random master secret for that application
+through the portal's file descriptor. Portal secrets use a document kind and
+authorization domain separate from the full Secret Service collection.
+
+The package registers the backend but does not select it automatically because
+switching from GNOME Keyring, KWallet, or another backend changes the master
+key and can make an existing sandbox-local keyring unreadable. See
+[Packaging](packaging/README.md#xdg-secret-portal) for the opt-in configuration.
 
 ## Vault lifecycle
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -131,5 +131,8 @@ resolution, so a reused process ID cannot inherit another process's grant.
   platform signing primitive.
 - Hardware binding cannot prevent an already authorized or compromised client
   from exfiltrating a secret returned to it.
+- The XDG Secret portal returns a per-application master key. A sandboxed
+  application may retain that key after Factorseal seals and can continue
+  opening its own encrypted local keyring until the process discards the key.
 - Losing the platform keys loses the protected data. Recovery is not
   implemented.

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -50,6 +50,17 @@ rustPlatform.buildRustPackage {
       factorseal.service --replace-fail "@INSTALL_DIR@" "$out/bin"
     install -Dm0644 factorseal.service \
       "$out/share/systemd/user/factorseal.service"
+    substitute ${../packaging/linux/factorseal-portal.service.in} \
+      factorseal-portal.service --replace-fail "@INSTALL_DIR@" "$out/bin"
+    install -Dm0644 factorseal-portal.service \
+      "$out/share/systemd/user/factorseal-portal.service"
+    substitute ${../packaging/linux/org.freedesktop.impl.portal.desktop.factorseal.service.in} \
+      org.freedesktop.impl.portal.desktop.factorseal.service \
+      --replace-fail "@INSTALL_DIR@" "$out/bin"
+    install -Dm0644 org.freedesktop.impl.portal.desktop.factorseal.service \
+      "$out/share/dbus-1/services/org.freedesktop.impl.portal.desktop.factorseal.service"
+    install -Dm0644 ${../packaging/linux/factorseal.portal} \
+      "$out/share/xdg-desktop-portal/portals/factorseal.portal"
     patchShebangs "$out/bin/factorseal-start"
 
     runHook postInstall

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -180,6 +180,28 @@ systemd's agent protocol and the askpass pipe; it is never written to the
 runtime directory. Logout, service stop, termination, or the lease deadline
 seals the vault.
 
+### XDG Secret portal
+
+The Linux package installs a D-Bus-activated
+`org.freedesktop.impl.portal.Secret` backend and its `factorseal.portal`
+descriptor. It is deliberately not selected automatically: changing Secret
+portal backends changes the per-application master key and can make an
+existing sandbox-local keyring unreadable.
+
+After starting with applications that have no data under another Secret
+portal backend, opt in with the desktop-specific `portals.conf` file under
+`$XDG_CONFIG_HOME/xdg-desktop-portal/`:
+
+```ini
+[preferred]
+org.freedesktop.impl.portal.Secret=factorseal;
+```
+
+Restart `xdg-desktop-portal` after changing its configuration. The backend
+returns one durable random master secret per portal-authenticated application
+ID. When the Factorseal agent is sealed or unavailable, retrieval fails rather
+than creating an unprotected fallback key.
+
 ## NixOS module
 
 The repository flake exports `nixosModules.factorseal`. A minimal system import

--- a/packaging/build-unix.sh
+++ b/packaging/build-unix.sh
@@ -76,7 +76,11 @@ cp "acceptance/$platform.sh" "$stage/$archive/run-acceptance.sh"
 chmod 0755 "$stage/$archive/run-acceptance.sh"
 
 if [ "$platform" = linux ]; then
-    mkdir -p "$stage/$archive/bin" "$stage/$archive/share/systemd/user"
+    mkdir -p \
+        "$stage/$archive/bin" \
+        "$stage/$archive/share/dbus-1/services" \
+        "$stage/$archive/share/systemd/user" \
+        "$stage/$archive/share/xdg-desktop-portal/portals"
     cp "$target_dir/release/factorseal" "$stage/$archive/bin/"
     cp packaging/linux/factorseal-start "$stage/$archive/bin/"
     # systemd needs an absolute ExecStart, so the unit is written for the
@@ -86,6 +90,14 @@ if [ "$platform" = linux ]; then
         packaging/linux/factorseal.service.in \
         > "$stage/$archive/share/systemd/user/factorseal.service"
     cp packaging/linux/factorseal.service.in "$stage/$archive/share/systemd/user/"
+    sed "s|@INSTALL_DIR@|$linux_install_dir|g" \
+        packaging/linux/factorseal-portal.service.in \
+        > "$stage/$archive/share/systemd/user/factorseal-portal.service"
+    sed "s|@INSTALL_DIR@|$linux_install_dir|g" \
+        packaging/linux/org.freedesktop.impl.portal.desktop.factorseal.service.in \
+        > "$stage/$archive/share/dbus-1/services/org.freedesktop.impl.portal.desktop.factorseal.service"
+    cp packaging/linux/factorseal.portal \
+        "$stage/$archive/share/xdg-desktop-portal/portals/"
     chmod 0755 \
         "$stage/$archive/bin/factorseal" \
         "$stage/$archive/bin/factorseal-start"

--- a/packaging/linux/factorseal-portal.service.in
+++ b/packaging/linux/factorseal-portal.service.in
@@ -1,0 +1,19 @@
+[Unit]
+Description=Factorseal XDG Secret portal backend
+Documentation=https://github.com/domenkozar/factorseal
+Wants=dbus.socket
+After=dbus.socket
+
+[Service]
+Type=dbus
+BusName=org.freedesktop.impl.portal.desktop.factorseal
+ExecStart=@INSTALL_DIR@/factorseal portal
+Restart=on-failure
+UMask=0077
+NoNewPrivileges=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+RestrictAddressFamilies=AF_UNIX
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native

--- a/packaging/linux/factorseal.portal
+++ b/packaging/linux/factorseal.portal
@@ -1,0 +1,5 @@
+[portal]
+DBusName=org.freedesktop.impl.portal.desktop.factorseal
+Interfaces=org.freedesktop.impl.portal.Secret;
+# Avoid legacy desktop-name auto-selection. Users opt in through portals.conf.
+UseIn=factorseal

--- a/packaging/linux/org.freedesktop.impl.portal.desktop.factorseal.service.in
+++ b/packaging/linux/org.freedesktop.impl.portal.desktop.factorseal.service.in
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=org.freedesktop.impl.portal.desktop.factorseal
+Exec=@INSTALL_DIR@/factorseal portal
+SystemdService=factorseal-portal.service

--- a/src/bin/factorseal.rs
+++ b/src/bin/factorseal.rs
@@ -11,6 +11,9 @@ mod commands;
 mod factor;
 #[path = "factorseal/platform.rs"]
 mod platform;
+#[cfg(target_os = "linux")]
+#[path = "factorseal/portal.rs"]
+mod portal;
 #[cfg(feature = "secretspec-provider")]
 #[path = "factorseal/provider.rs"]
 mod provider;
@@ -22,6 +25,8 @@ use commands::{
     seal_vault, set_project_value, show_status,
 };
 use factor::FactorSource;
+#[cfg(target_os = "linux")]
+use platform::native_client;
 
 const MAX_FACTOR_BYTES: u64 = 64 * 1024;
 const MAX_PROJECT_VALUE_BYTES: u64 = 64 * 1024;
@@ -110,6 +115,10 @@ enum CliError {
     #[error("SecretSpec provider protocol failed: {0}")]
     ProviderProtocol(String),
 
+    #[cfg(target_os = "linux")]
+    #[error("{0}")]
+    SecretPortal(String),
+
     #[cfg(feature = "secretspec-provider")]
     #[error("could not publish SecretSpec provider discovery: {0}")]
     SecretSpecDiscovery(String),
@@ -185,6 +194,10 @@ fn run(cli: Cli) -> Result<(), CliError> {
         Command::Permissions { action } => manage_permissions(&root, socket, factor, &action),
         #[cfg(feature = "secretspec-provider")]
         Command::Provider => provider::serve(&root, socket),
+        #[cfg(target_os = "linux")]
+        Command::Portal => {
+            portal::serve(native_client(&root, socket)?).map_err(CliError::SecretPortal)
+        }
     }
 }
 

--- a/src/bin/factorseal/cli.rs
+++ b/src/bin/factorseal/cli.rs
@@ -175,6 +175,11 @@ pub(super) enum Command {
     /// Serve the SecretSpec external-provider protocol over standard I/O.
     #[cfg(feature = "secretspec-provider")]
     Provider,
+
+    /// Serve the XDG Secret portal backend on the Linux session bus.
+    #[cfg(target_os = "linux")]
+    #[command(hide = true)]
+    Portal,
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/bin/factorseal/portal.rs
+++ b/src/bin/factorseal/portal.rs
@@ -1,0 +1,463 @@
+//! XDG Secret portal backend backed by the live Factorseal agent.
+//!
+//! `xdg-desktop-portal` authenticates the sandbox and forwards its application
+//! ID to this backend. The backend itself is a D-Bus-activated process and is
+//! the only principal that receives Factorseal's native socket capability.
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Write as _;
+use std::sync::{Arc, Mutex};
+
+use factorseal::{
+    LINUX_SECRET_PORTAL_NAMESPACE, LinuxVaultClient, VaultAction, VaultClient, VaultError,
+    VaultRequest, VaultResponseBody, WireSecret, WireSecretAddress,
+};
+use zbus::names::BusName;
+use zbus::object_server::ObjectServer;
+use zbus::zvariant::{OwnedFd, OwnedObjectPath, OwnedValue};
+use zbus::{Connection, fdo, interface};
+
+const BACKEND_BUS_NAME: &str = "org.freedesktop.impl.portal.desktop.factorseal";
+const FRONTEND_BUS_NAME: &str = "org.freedesktop.portal.Desktop";
+const PORTAL_PATH: &str = "/org/freedesktop/portal/desktop";
+const SECRET_BYTES: usize = 64;
+const RESPONSE_SUCCESS: u32 = 0;
+const RESPONSE_CANCELLED: u32 = 1;
+const RESPONSE_OTHER: u32 = 2;
+
+type Results = HashMap<String, OwnedValue>;
+
+pub(super) fn serve(client: LinuxVaultClient) -> Result<(), String> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("could not start the Secret portal runtime: {error}"))?;
+    runtime.block_on(async move {
+        let backend = SecretPortal {
+            store: PortalStore::new(Arc::new(client)),
+        };
+        let connection = zbus::connection::Builder::session()
+            .map_err(portal_error)?
+            .name(BACKEND_BUS_NAME)
+            .map_err(portal_error)?
+            .serve_at(PORTAL_PATH, backend)
+            .map_err(portal_error)?
+            .build()
+            .await
+            .map_err(portal_error)?;
+        connection.closed().await;
+        Ok(())
+    })
+}
+
+struct PortalStore {
+    client: Arc<dyn VaultClient>,
+    /// Serialize get-or-create so concurrent first requests for one app cannot
+    /// receive different master secrets.
+    mutation: Mutex<()>,
+}
+
+impl PortalStore {
+    fn new(client: Arc<dyn VaultClient>) -> Arc<Self> {
+        Arc::new(Self {
+            client,
+            mutation: Mutex::new(()),
+        })
+    }
+
+    fn retrieve(&self, app_id: &str) -> Result<WireSecret, VaultError> {
+        let address = application_address(app_id)?;
+        let _serialized = self
+            .mutation
+            .lock()
+            .map_err(|_| VaultError::WorkerUnavailable)?;
+
+        match self.call(VaultAction::Get {
+            namespace: LINUX_SECRET_PORTAL_NAMESPACE.to_vec(),
+            address: address.clone(),
+        })? {
+            VaultResponseBody::Secret { value: Some(value) } => {
+                validate_secret(&value)?;
+                Ok(value)
+            }
+            VaultResponseBody::Secret { value: None } => {
+                let mut value = vec![0_u8; SECRET_BYTES];
+                getrandom::fill(&mut value)?;
+                let value = WireSecret::new(value);
+                match self.call(VaultAction::Put {
+                    namespace: LINUX_SECRET_PORTAL_NAMESPACE.to_vec(),
+                    address,
+                    value: WireSecret::new(value.expose().to_vec()),
+                    evict_at: None,
+                })? {
+                    VaultResponseBody::Stored => Ok(value),
+                    _ => Err(unexpected_response()),
+                }
+            }
+            _ => Err(unexpected_response()),
+        }
+    }
+
+    fn call(&self, action: VaultAction) -> Result<VaultResponseBody, VaultError> {
+        let request = VaultRequest::new(action)?;
+        self.client
+            .request(&request)?
+            .result
+            .map_err(|error| VaultError::Protocol(error.message))
+    }
+}
+
+struct SecretPortal {
+    store: Arc<PortalStore>,
+}
+
+#[allow(clippy::too_many_arguments, clippy::unused_self)]
+#[interface(name = "org.freedesktop.impl.portal.Secret")]
+impl SecretPortal {
+    #[zbus(out_args("response", "results"))]
+    async fn retrieve_secret(
+        &self,
+        handle: OwnedObjectPath,
+        app_id: String,
+        fd: OwnedFd,
+        options: HashMap<String, OwnedValue>,
+        #[zbus(header)] header: zbus::message::Header<'_>,
+        #[zbus(connection)] connection: &Connection,
+        #[zbus(object_server)] server: &ObjectServer,
+    ) -> fdo::Result<(u32, Results)> {
+        drop(options);
+        require_portal_frontend(connection, &header).await?;
+
+        let request = Arc::new(RequestState::default());
+        let inserted = server
+            .at(
+                handle.clone(),
+                PortalRequest {
+                    request: Arc::clone(&request),
+                },
+            )
+            .await
+            .map_err(failed)?;
+        if !inserted {
+            return Err(fdo::Error::ObjectPathInUse(handle.to_string()));
+        }
+
+        let response = self
+            .complete_retrieve(app_id, fd, &request)
+            .await
+            .unwrap_or_else(|error| {
+                eprintln!("factorseal portal: {error}");
+                (RESPONSE_OTHER, Results::new())
+            });
+        server
+            .remove::<PortalRequest, _>(handle.as_str())
+            .await
+            .map_err(failed)?;
+        Ok(response)
+    }
+
+    #[zbus(property)]
+    const fn version(&self) -> u32 {
+        1
+    }
+}
+
+impl SecretPortal {
+    async fn complete_retrieve(
+        &self,
+        app_id: String,
+        fd: OwnedFd,
+        request: &RequestState,
+    ) -> Result<(u32, Results), VaultError> {
+        use std::sync::atomic::Ordering;
+
+        if request.cancelled.load(Ordering::Acquire) {
+            return Ok((RESPONSE_CANCELLED, Results::new()));
+        }
+        let store = Arc::clone(&self.store);
+        let mut retrieval = tokio::task::spawn_blocking(move || store.retrieve(&app_id));
+        let secret = loop {
+            match tokio::time::timeout(std::time::Duration::from_millis(50), &mut retrieval).await {
+                Ok(result) => {
+                    break result.map_err(|error| {
+                        VaultError::Protocol(format!(
+                            "Secret portal retrieval task failed: {error}"
+                        ))
+                    })??;
+                }
+                Err(_) if request.cancelled.load(Ordering::Acquire) => {
+                    return Ok((RESPONSE_CANCELLED, Results::new()));
+                }
+                Err(_) => {}
+            }
+        };
+        if request.cancelled.load(Ordering::Acquire) {
+            return Ok((RESPONSE_CANCELLED, Results::new()));
+        }
+
+        let owned: std::os::fd::OwnedFd = fd.into();
+        let mut output = File::from(owned);
+        output
+            .write_all(secret.expose())
+            .and_then(|()| output.flush())
+            .map_err(|error| {
+                VaultError::Protocol(format!("could not write portal secret: {error}"))
+            })?;
+        Ok((RESPONSE_SUCCESS, Results::new()))
+    }
+}
+
+struct PortalRequest {
+    request: Arc<RequestState>,
+}
+
+#[derive(Default)]
+struct RequestState {
+    cancelled: std::sync::atomic::AtomicBool,
+}
+
+#[interface(name = "org.freedesktop.impl.portal.Request")]
+impl PortalRequest {
+    fn close(&self) {
+        self.request
+            .cancelled
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
+}
+
+async fn require_portal_frontend(
+    connection: &Connection,
+    header: &zbus::message::Header<'_>,
+) -> fdo::Result<()> {
+    let sender = header
+        .sender()
+        .ok_or_else(|| fdo::Error::AccessDenied("D-Bus caller has no unique name".to_owned()))?;
+    let name = BusName::try_from(FRONTEND_BUS_NAME).map_err(failed)?;
+    let owner = fdo::DBusProxy::new(connection)
+        .await
+        .map_err(failed)?
+        .get_name_owner(name)
+        .await
+        .map_err(failed)?;
+    if owner.as_str() != sender.as_str() {
+        return Err(fdo::Error::AccessDenied(
+            "only xdg-desktop-portal may call the Secret backend".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn application_address(app_id: &str) -> Result<WireSecretAddress, VaultError> {
+    if app_id.is_empty() || app_id.len() > 4 * 1024 {
+        return Err(VaultError::Protocol(
+            "portal application ID is empty or too long".to_owned(),
+        ));
+    }
+    let address = WireSecretAddress::new(format!("application/{app_id}"), None);
+    address.validate()?;
+    Ok(address)
+}
+
+fn validate_secret(secret: &WireSecret) -> Result<(), VaultError> {
+    if secret.expose().len() != SECRET_BYTES {
+        return Err(VaultError::InvalidData(
+            "stored Secret portal master key has the wrong length".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn unexpected_response() -> VaultError {
+    VaultError::Protocol("unexpected Secret portal vault response".to_owned())
+}
+
+fn failed(error: impl std::fmt::Display) -> fdo::Error {
+    fdo::Error::Failed(error.to_string())
+}
+
+fn portal_error(error: impl std::fmt::Display) -> String {
+    format!("Secret portal D-Bus error: {error}")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read as _;
+    use std::os::fd::OwnedFd as StdOwnedFd;
+    use std::os::unix::net::UnixStream;
+
+    use factorseal::{VaultResponse, VaultResponseError, VaultResponseErrorCode};
+    use zbus::Proxy;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct MemoryClient {
+        values: Mutex<HashMap<String, Vec<u8>>>,
+    }
+
+    impl VaultClient for MemoryClient {
+        fn request(&self, request: &VaultRequest) -> Result<VaultResponse, VaultError> {
+            let body = match &request.action {
+                VaultAction::Get { namespace, address } => {
+                    assert_eq!(namespace, LINUX_SECRET_PORTAL_NAMESPACE);
+                    VaultResponseBody::Secret {
+                        value: self
+                            .values
+                            .lock()
+                            .unwrap()
+                            .get(&address.item)
+                            .cloned()
+                            .map(WireSecret::new),
+                    }
+                }
+                VaultAction::Put {
+                    namespace,
+                    address,
+                    value,
+                    evict_at,
+                } => {
+                    assert_eq!(namespace, LINUX_SECRET_PORTAL_NAMESPACE);
+                    assert_eq!(*evict_at, None);
+                    self.values
+                        .lock()
+                        .unwrap()
+                        .insert(address.item.clone(), value.expose().to_vec());
+                    VaultResponseBody::Stored
+                }
+                action => panic!("unexpected portal action: {action:?}"),
+            };
+            Ok(VaultResponse::success(request.request_id(), body))
+        }
+    }
+
+    struct SealedClient;
+
+    impl VaultClient for SealedClient {
+        fn request(&self, request: &VaultRequest) -> Result<VaultResponse, VaultError> {
+            Ok(VaultResponse::failure(
+                request.request_id(),
+                VaultResponseError {
+                    code: VaultResponseErrorCode::Sealed,
+                    message: "the vault is sealed".to_owned(),
+                    interaction: None,
+                },
+            ))
+        }
+    }
+
+    #[test]
+    fn master_secret_is_stable_and_isolated_by_application_id() {
+        let store = PortalStore::new(Arc::new(MemoryClient::default()));
+        let first = store.retrieve("dev.factorseal.First").unwrap();
+        let again = store.retrieve("dev.factorseal.First").unwrap();
+        let other = store.retrieve("dev.factorseal.Other").unwrap();
+
+        assert_eq!(first.expose().len(), SECRET_BYTES);
+        assert_eq!(first.expose(), again.expose());
+        assert_ne!(first.expose(), other.expose());
+    }
+
+    #[test]
+    fn concurrent_first_retrievals_return_one_master_secret() {
+        let store = PortalStore::new(Arc::new(MemoryClient::default()));
+        let threads = (0..8)
+            .map(|_| {
+                let store = Arc::clone(&store);
+                std::thread::spawn(move || {
+                    store
+                        .retrieve("dev.factorseal.Concurrent")
+                        .unwrap()
+                        .expose()
+                        .to_vec()
+                })
+            })
+            .collect::<Vec<_>>();
+        let values = threads
+            .into_iter()
+            .map(|thread| thread.join().unwrap())
+            .collect::<Vec<_>>();
+
+        assert!(values.windows(2).all(|pair| pair[0] == pair[1]));
+    }
+
+    #[test]
+    fn sealed_agent_does_not_produce_a_fallback_secret() {
+        let store = PortalStore::new(Arc::new(SealedClient));
+        assert!(store.retrieve("dev.factorseal.Sealed").is_err());
+    }
+
+    #[test]
+    fn portal_dbus_method_writes_the_stable_secret_to_the_passed_fd() {
+        if std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_none() {
+            return;
+        }
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let backend = SecretPortal {
+                store: PortalStore::new(Arc::new(MemoryClient::default())),
+            };
+            let _server = zbus::connection::Builder::session()
+                .unwrap()
+                .name(BACKEND_BUS_NAME)
+                .unwrap()
+                .serve_at(PORTAL_PATH, backend)
+                .unwrap()
+                .build()
+                .await
+                .unwrap();
+            let frontend = Connection::session().await.unwrap();
+            frontend
+                .request_name_with_flags(
+                    FRONTEND_BUS_NAME,
+                    zbus::fdo::RequestNameFlags::DoNotQueue.into(),
+                )
+                .await
+                .unwrap();
+            let proxy = Proxy::new(
+                &frontend,
+                BACKEND_BUS_NAME,
+                PORTAL_PATH,
+                "org.freedesktop.impl.portal.Secret",
+            )
+            .await
+            .unwrap();
+
+            let first = retrieve_over_dbus(&proxy, "first").await;
+            let second = retrieve_over_dbus(&proxy, "second").await;
+            assert_eq!(first, second);
+            assert_eq!(first.len(), SECRET_BYTES);
+        });
+    }
+
+    async fn retrieve_over_dbus(proxy: &Proxy<'_>, suffix: &str) -> Vec<u8> {
+        let (mut read, write) = UnixStream::pair().unwrap();
+        let raw: StdOwnedFd = write.into();
+        let fd = OwnedFd::from(raw);
+        let handle = OwnedObjectPath::try_from(format!(
+            "/org/freedesktop/portal/desktop/request/factorseal/{suffix}"
+        ))
+        .unwrap();
+        let (response, results): (u32, Results) = proxy
+            .call(
+                "RetrieveSecret",
+                &(
+                    handle,
+                    "dev.factorseal.PortalTest".to_owned(),
+                    fd,
+                    Results::new(),
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response, RESPONSE_SUCCESS);
+        assert!(results.is_empty());
+
+        let mut secret = vec![0_u8; SECRET_BYTES];
+        read.read_exact(&mut secret).unwrap();
+        secret
+    }
+}

--- a/src/bin/factorseal/tests.rs
+++ b/src/bin/factorseal/tests.rs
@@ -186,6 +186,13 @@ fn agent_policy_and_root_are_explicitly_configurable() {
     assert_eq!(maximum_seconds, 20);
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn secret_portal_backend_is_an_internal_cli_command() {
+    let cli = Cli::try_parse_from(["factorseal", "portal"]).unwrap();
+    assert!(matches!(cli.command, Command::Portal));
+}
+
 #[test]
 fn agent_waits_for_initialization_metadata() {
     let directory = tempfile::tempdir().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub use vault::{CallerIdentity, CallerPlatform, GrantPermission, UnsealLeasePoli
 pub use vault::{HardwareBackend, KeyProtector, KeyProtectorFactory};
 
 #[cfg(all(feature = "vault-client", target_os = "linux"))]
-pub use vault::LinuxVaultClient;
+pub use vault::{LINUX_SECRET_PORTAL_NAMESPACE, LinuxVaultClient};
 #[cfg(all(feature = "vault-client", target_os = "linux"))]
 pub type NativeVaultClient = LinuxVaultClient;
 

--- a/src/vault/linux.rs
+++ b/src/vault/linux.rs
@@ -22,12 +22,11 @@ use nix::unistd::getuid;
 use super::transport::unix_socket::{
     accept_until_sealed, bind_listener, install_shutdown_signal_handler, validate_socket_options,
 };
-#[cfg(test)]
 use super::transport::unix_time;
 use super::transport::{hash_file, hash_open_file, path_io_error};
 use super::{
-    CallerIdentity, CallerIdentityCache, CallerPlatform, LifecycleSignal, VaultError, VaultResult,
-    VaultService,
+    CallerIdentity, CallerIdentityCache, CallerPlatform, GrantPermission,
+    LINUX_SECRET_PORTAL_NAMESPACE, LifecycleSignal, VaultError, VaultResult, VaultService,
 };
 #[cfg(all(test, feature = "hardware"))]
 use super::{LinuxVaultClient, VaultClient, VaultRequest};
@@ -39,6 +38,10 @@ const SESSION_ID_ENVIRONMENT: [&str; 2] = ["FACTORSEAL_SESSION_ID", "XDG_SESSION
 
 /// Linux per-user socket configuration.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "embedders independently select signal, lifecycle, and desktop adapters"
+)]
 pub struct LinuxVaultOptions {
     pub socket_path: PathBuf,
     pub poll_interval: Duration,
@@ -52,6 +55,9 @@ pub struct LinuxVaultOptions {
     /// Publish `org.freedesktop.secrets` on the session bus. Disable only for
     /// embedded and socket-only test servers.
     pub install_secret_service: bool,
+    /// Authorize the separately activated XDG Secret portal broker. Disable
+    /// only for embedded and socket-only test servers.
+    pub install_secret_portal: bool,
 }
 
 impl LinuxVaultOptions {
@@ -63,6 +69,7 @@ impl LinuxVaultOptions {
             install_signal_handler: true,
             install_lifecycle_monitor: true,
             install_secret_service: true,
+            install_secret_portal: true,
         }
     }
 }
@@ -110,6 +117,22 @@ pub fn serve_linux_vault_with_lifecycle(
     }
     if options.install_signal_handler {
         install_shutdown_signal_handler(&stopping)?;
+    }
+
+    if options.install_secret_portal {
+        let executable = std::env::current_exe().map_err(|error| {
+            VaultError::Protocol(format!(
+                "could not resolve Factorseal portal executable: {error}"
+            ))
+        })?;
+        let caller = linux_caller_identity_for_executable(executable)?;
+        service.authorize_secret_portal_namespace(
+            &caller,
+            LINUX_SECRET_PORTAL_NAMESPACE,
+            [GrantPermission::Get, GrantPermission::Put],
+            None,
+            unix_time()?,
+        )?;
     }
 
     // Every exit from the loop discards the hardware-unwrapped keys, including
@@ -634,6 +657,7 @@ mod tests {
             install_signal_handler: false,
             install_lifecycle_monitor: false,
             install_secret_service: false,
+            install_secret_portal: false,
         };
         assert!(serve_linux_vault(&service, &options).is_err());
         assert!(
@@ -649,6 +673,7 @@ mod tests {
         assert!(options.install_signal_handler);
         assert!(options.install_lifecycle_monitor);
         assert!(options.install_secret_service);
+        assert!(options.install_secret_portal);
     }
 
     #[test]
@@ -702,6 +727,7 @@ mod tests {
             install_signal_handler: false,
             install_lifecycle_monitor: false,
             install_secret_service: false,
+            install_secret_portal: false,
         };
         let server_service = Arc::clone(&service);
         let server = std::thread::spawn(move || serve_linux_vault(&server_service, &options));

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -454,6 +454,7 @@ impl fmt::Display for DeviceKeyId {
 #[non_exhaustive]
 pub enum DocumentKind {
     Authorization,
+    LinuxSecretPortal,
     LinuxSecretService,
     LocalKeyring,
     SecretSpecProject,
@@ -465,6 +466,7 @@ impl DocumentKind {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Authorization => "authorization",
+            Self::LinuxSecretPortal => "linux-secret-portal",
             Self::LinuxSecretService => "linux-secret-service",
             Self::LocalKeyring => "local-keyring",
             Self::SecretSpecProject => "secretspec-project",
@@ -476,6 +478,7 @@ impl DocumentKind {
     pub(crate) fn parse(value: &str) -> VaultResult<Self> {
         match value {
             "authorization" => Ok(Self::Authorization),
+            "linux-secret-portal" => Ok(Self::LinuxSecretPortal),
             "linux-secret-service" => Ok(Self::LinuxSecretService),
             "local-keyring" => Ok(Self::LocalKeyring),
             "secretspec-project" => Ok(Self::SecretSpecProject),
@@ -486,6 +489,13 @@ impl DocumentKind {
         }
     }
 }
+
+/// Reserved native-protocol namespace used by the XDG Secret portal backend.
+///
+/// The portal executable is the authenticated native client. Sandboxed
+/// application IDs arrive separately from the trusted portal frontend and
+/// become addresses within this isolated document kind.
+pub const LINUX_SECRET_PORTAL_NAMESPACE: &[u8] = b"factorseal/secret-portal/v1";
 
 /// Opaque identifier for one encrypted Automerge document.
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]

--- a/src/vault/protocol/grant.rs
+++ b/src/vault/protocol/grant.rs
@@ -387,6 +387,7 @@ fn document_kind_tag(kind: DocumentKind) -> u8 {
         DocumentKind::LocalKeyring => 3,
         DocumentKind::SecretSpecProject => 4,
         DocumentKind::SecretSpecProviderCache => 5,
+        DocumentKind::LinuxSecretPortal => 6,
     }
 }
 

--- a/src/vault/protocol/service/actions.rs
+++ b/src/vault/protocol/service/actions.rs
@@ -3,8 +3,8 @@
 use zeroize::Zeroizing;
 
 use crate::vault::{
-    DocumentKind, DocumentOperation, SecretAddress, SecretSpecAddress, VaultError, VaultResult,
-    VaultStore,
+    DocumentKind, DocumentOperation, LINUX_SECRET_PORTAL_NAMESPACE, SecretAddress,
+    SecretSpecAddress, VaultError, VaultResult, VaultStore,
 };
 
 use super::super::grant::{GrantRequirement, require_grant};
@@ -355,6 +355,16 @@ pub(super) fn scope_action(action: VaultAction) -> ScopedAction {
             if namespace == b"factorseal/secret-service/v1" =>
         {
             DocumentKind::LinuxSecretService
+        }
+        VaultAction::Get { ref namespace, .. }
+        | VaultAction::Put { ref namespace, .. }
+        | VaultAction::Mutate { ref namespace, .. }
+        | VaultAction::Delete { ref namespace, .. }
+        | VaultAction::Clear { ref namespace }
+        | VaultAction::Seal { ref namespace }
+            if namespace == LINUX_SECRET_PORTAL_NAMESPACE =>
+        {
+            DocumentKind::LinuxSecretPortal
         }
         _ => DocumentKind::LocalKeyring,
     };

--- a/src/vault/protocol/service/authorization.rs
+++ b/src/vault/protocol/service/authorization.rs
@@ -152,6 +152,28 @@ impl VaultService {
         )
     }
 
+    /// Persist approval for the built-in XDG Secret portal broker.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn authorize_secret_portal_namespace(
+        &self,
+        caller: &CallerIdentity,
+        namespace: &[u8],
+        permissions: impl IntoIterator<Item = GrantPermission>,
+        expires_at: Option<u64>,
+        now: u64,
+    ) -> VaultResult<()> {
+        self.authorize(
+            caller,
+            AuthorizationTarget::Namespace {
+                scope: DocumentKind::LinuxSecretPortal,
+                namespace,
+            },
+            permissions,
+            expires_at,
+            now,
+        )
+    }
+
     /// Persist approval for a disposable application-cache namespace.
     pub fn authorize_cache_namespace(
         &self,

--- a/src/vault/protocol/service/tests.rs
+++ b/src/vault/protocol/service/tests.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use super::*;
+use crate::vault::LINUX_SECRET_PORTAL_NAMESPACE;
 use crate::{DocumentKind, MAX_LIST_PAGE_SIZE, SecretSpecAddress, SecretSpecCoordinates, Vault};
 
 fn service(now: u64, policy: UnsealLeasePolicy) -> (tempfile::TempDir, VaultService) {
@@ -75,6 +76,61 @@ fn typed_actions_select_semantic_document_kinds() {
         scope_action(VaultAction::Status).scope,
         DocumentKind::LocalKeyring
     );
+    assert_eq!(
+        scope_action(VaultAction::Get {
+            namespace: LINUX_SECRET_PORTAL_NAMESPACE.to_vec(),
+            address: WireSecretAddress::new("application/dev.factorseal.Test", None),
+        })
+        .scope,
+        DocumentKind::LinuxSecretPortal
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn secret_portal_grant_authorizes_only_its_reserved_document_kind() {
+    let (_directory, service) = service(100, UnsealLeasePolicy::default());
+    let caller = caller();
+    service
+        .authorize_secret_portal_namespace(
+            &caller,
+            LINUX_SECRET_PORTAL_NAMESPACE,
+            [GrantPermission::Get, GrantPermission::Put],
+            None,
+            100,
+        )
+        .unwrap();
+    let address = WireSecretAddress::new("application/dev.factorseal.Test", None);
+
+    let put = service.handle(
+        &caller,
+        VaultRequest::new(VaultAction::Put {
+            namespace: LINUX_SECRET_PORTAL_NAMESPACE.to_vec(),
+            address: address.clone(),
+            value: WireSecret::new(b"portal-key".to_vec()),
+            evict_at: None,
+        })
+        .unwrap(),
+        100,
+    );
+    assert!(matches!(put.result, Ok(VaultResponseBody::Stored)));
+
+    let local = service.handle(
+        &caller,
+        VaultRequest::new(VaultAction::Get {
+            namespace: b"factorseal/other-keyring/v1".to_vec(),
+            address,
+        })
+        .unwrap(),
+        100,
+    );
+    assert!(matches!(
+        local.result,
+        Err(VaultResponseError {
+            code: VaultResponseErrorCode::AuthorizationRequired,
+            ..
+        })
+    ));
 }
 
 #[test]

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -155,6 +155,42 @@ fn the_linux_unit_uses_askpass_without_a_password_file() {
 }
 
 #[test]
+fn the_linux_package_registers_an_opt_in_secret_portal_backend() {
+    let descriptor = packaging("linux/factorseal.portal");
+    let activation = packaging("linux/org.freedesktop.impl.portal.desktop.factorseal.service.in");
+    let unit = packaging("linux/factorseal-portal.service.in");
+    let builder = packaging("build-unix.sh");
+    let nix_package = repository_file("nix/package.nix");
+
+    for contents in [&descriptor, &activation, &unit] {
+        assert!(contents.contains("org.freedesktop.impl.portal.desktop.factorseal"));
+    }
+    assert!(descriptor.contains("Interfaces=org.freedesktop.impl.portal.Secret;"));
+    assert!(
+        descriptor.contains("UseIn=factorseal"),
+        "legacy portal selection must not replace the desktop keyring automatically"
+    );
+    assert!(activation.contains("Exec=@INSTALL_DIR@/factorseal portal"));
+    assert!(activation.contains("SystemdService=factorseal-portal.service"));
+    assert!(unit.contains("Type=dbus") && unit.contains("factorseal portal"));
+
+    for destination in [
+        "share/dbus-1/services",
+        "share/systemd/user/factorseal-portal.service",
+        "share/xdg-desktop-portal/portals",
+    ] {
+        assert!(
+            builder.contains(destination),
+            "Linux archive omits {destination}"
+        );
+        assert!(
+            nix_package.contains(destination),
+            "Nix package omits {destination}"
+        );
+    }
+}
+
+#[test]
 fn the_linux_starter_hands_an_overridden_socket_to_the_unit() {
     let starter = packaging("linux/factorseal-start");
 


### PR DESCRIPTION
## Summary

- add a D-Bus-activated `org.freedesktop.impl.portal.Secret` backend with stable, random per-app master keys
- isolate portal keys in a dedicated document/grant scope and fail closed while the vault is sealed
- ship opt-in portal, D-Bus, and systemd registration and document migration and key-lifetime caveats

## Testing

- `devenv shell -- dbus-run-session -- cargo test --all-features`
- `devenv shell cargo clippy --all-features --all-targets -- -D warnings`
- `devenv shell cargo check --locked --no-default-features --features vault,cli,hardware --bin factorseal`
- `nix build .#checks.x86_64-linux.package --no-write-lock-file`