### PR TITLE
Add desktop appearance and security preferences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,6 +2492,7 @@ dependencies = [
  "native-theme-qt",
  "notify 8.2.0",
  "rfd",
+ "serde",
  "serde_json",
  "smol",
  "tempfile",

--- a/factorseal-desktop/Cargo.toml
+++ b/factorseal-desktop/Cargo.toml
@@ -17,11 +17,13 @@ fs2 = "0.4.3"
 gpui = "=0.2.2"
 gpui-component = { git = "https://github.com/longbridge/gpui-component.git", rev = "39c2c86dbee7" }
 gpui-component-assets = { git = "https://github.com/longbridge/gpui-component.git", rev = "39c2c86dbee7" }
-native-theme = "=0.5.7"
 gpui_platform = { git = "https://github.com/zed-industries/zed.git" }
 gpui-tray = { path = "../crates/gpui-tray" }
 rfd = { version = "0.15.4", default-features = false, features = ["async-std", "xdg-portal"] }
 serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+native-theme = "=0.5.7"
+tempfile = "3.23"
 smol = "2.0"
 zeroize = "1.8"
 
@@ -34,9 +36,6 @@ native-theme-gtk = "=0.1.1"
 native-theme-qt = "=0.1.0"
 notify = "=8.2.0"
 xdg = "=3.0.0"
-
-[dev-dependencies]
-tempfile = "3.23"
 
 [lints.rust]
 unsafe_code = "deny"

--- a/factorseal-desktop/src/app.rs
+++ b/factorseal-desktop/src/app.rs
@@ -3,10 +3,11 @@ use std::sync::Arc;
 
 use gpui::{
     AnyWindowHandle, App, Bounds, Context, Div, Global, Hsla, MenuItem, Render, Subscription, Task,
-    Window, WindowBounds, WindowOptions, actions, div, prelude::*, px, size, svg,
+    Window, WindowBounds, WindowOptions, actions, div, prelude::*, px, rems, size, svg,
 };
 use gpui_component::{
-    ActiveTheme as _, Disableable as _, Root, Selectable as _, Sizable as _, Size, StyledExt as _,
+    ActiveTheme as _, Disableable as _, IconName, Root, Selectable as _, Sizable as _, Size,
+    StyledExt as _,
     button::{Button, ButtonVariants as _},
     checkbox::Checkbox,
     h_flex,
@@ -49,6 +50,12 @@ impl Global for DesktopWindow {}
 struct RuntimeGlobal(Arc<DesktopRuntime>);
 
 impl Global for RuntimeGlobal {}
+
+pub(crate) fn set_next_lease(lease: crate::runtime::LeasePolicy, cx: &App) {
+    if let Some(runtime) = cx.try_global::<RuntimeGlobal>() {
+        runtime.0.set_next_lease(lease);
+    }
+}
 
 struct DesktopStatus {
     unsealed: bool,
@@ -146,7 +153,7 @@ fn brand_mark(size: f32, color: Hsla) -> impl IntoElement {
         } else {
             branding::MARK_ASSET
         })
-        .size(px(size))
+        .size(rems(size / 16.))
         .text_color(color)
 }
 
@@ -171,14 +178,14 @@ fn field_label(label: &'static str, field: impl IntoElement) -> Div {
 fn search_icon(color: Hsla) -> impl IntoElement {
     svg()
         .path(branding::SEARCH_ASSET)
-        .size(px(14.))
+        .size(rems(0.875))
         .text_color(color)
 }
 
 fn close_icon(color: Hsla) -> impl IntoElement {
     svg()
         .path(branding::CLOSE_ASSET)
-        .size(px(14.))
+        .size(rems(0.875))
         .text_color(color)
 }
 
@@ -535,6 +542,8 @@ fn selection_for_search(selection: Option<&VaultSelection>) -> Option<VaultSelec
 
 #[allow(clippy::struct_excessive_bools)]
 struct DesktopView {
+    settings_open: bool,
+    settings: gpui::Entity<crate::settings_view::SettingsView>,
     runtime: Arc<DesktopRuntime>,
     snapshot: Snapshot,
     selected_group: Option<factorseal::UnlockGroup>,
@@ -588,6 +597,7 @@ impl DesktopView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
+        let settings = cx.new(|cx| crate::settings_view::SettingsView::new(window, cx));
         let selected_group = snapshot
             .metadata()
             .map(|metadata| metadata.preferred_unlock_group().clone());
@@ -639,6 +649,8 @@ impl DesktopView {
             },
         );
         Self {
+            settings_open: false,
+            settings,
             runtime,
             snapshot,
             selected_group,
@@ -1249,9 +1261,9 @@ impl DesktopView {
                 )
                 .child(
                     div()
-                        .min_w(px(24.))
+                        .min_w(rems(24. / 16.))
                         .px_2()
-                        .py(px(2.))
+                        .py(rems(2. / 16.))
                         .rounded_full()
                         .bg(if category_selected {
                             theme.primary_foreground.opacity(0.16)
@@ -1324,9 +1336,9 @@ impl DesktopView {
                     .child("Personal secrets")
                     .child(
                         div()
-                            .min_w(px(24.))
+                            .min_w(rems(24. / 16.))
                             .px_2()
-                            .py(px(2.))
+                            .py(rems(2. / 16.))
                             .rounded_full()
                             .bg(if selected {
                                 theme.primary_foreground.opacity(0.16)
@@ -1388,9 +1400,9 @@ impl DesktopView {
                 .child("Access")
                 .child(
                     div()
-                        .min_w(px(24.))
+                        .min_w(rems(24. / 16.))
                         .px_2()
-                        .py(px(2.))
+                        .py(rems(2. / 16.))
                         .rounded_full()
                         .bg(if access_selected {
                             theme.primary_foreground.opacity(0.16)
@@ -1781,8 +1793,8 @@ impl DesktopView {
                     .child(
                         h_flex()
                             .flex_none()
-                            .w(px(24.))
-                            .h(px(24.))
+                            .w(rems(24. / 16.))
+                            .h(rems(24. / 16.))
                             .items_center()
                             .justify_center()
                             .rounded_full()
@@ -2125,7 +2137,7 @@ impl DesktopView {
             v_flex()
                 .w_full()
                 .min_w_0()
-                .max_w(px(820.))
+                .max_w(rems(820. / 16.))
                 .gap_4()
                 .p_6()
                 .child(div().text_color(theme.muted_foreground).child(description))
@@ -2196,7 +2208,7 @@ impl DesktopView {
                 )
                 .child(
                     div()
-                        .max_w(px(420.))
+                        .max_w(rems(420. / 16.))
                         .text_center()
                         .text_color(theme.muted_foreground)
                         .child(if entry_count == 0 {
@@ -2293,19 +2305,65 @@ impl DesktopView {
         }
     }
 
+    fn render_vault_workspace(
+        &self,
+        contents: &VaultContents,
+        browser_height: gpui::Pixels,
+        compact: bool,
+        cx: &mut Context<Self>,
+    ) -> Div {
+        let theme = cx.theme().clone();
+        let corner = crate::appearance::rem_size(cx) * 0.75 - px(1.);
+        let transfer_selected = matches!(
+            self.selected_vault_item.as_ref(),
+            Some(VaultSelection::Import | VaultSelection::Export)
+        );
+        h_flex()
+            .w_full()
+            .h(browser_height)
+            .when(compact, gpui::Styled::flex_col)
+            .rounded_xl()
+            .border_1()
+            .border_color(theme.border)
+            .overflow_hidden()
+            .bg(theme.popover)
+            .when(!transfer_selected, |workspace| {
+                workspace.child(
+                    div()
+                        .w(rems(232. / 16.))
+                        .flex_none()
+                        .h_full()
+                        .when(compact, |sidebar| sidebar.w_full().h(rems(180. / 16.)))
+                        .pl_5()
+                        .py_5()
+                        .bg(theme.sidebar)
+                        .rounded_tl(corner)
+                        .when(compact, |sidebar| sidebar.rounded_tr(corner).border_b_1())
+                        .when(!compact, |sidebar| sidebar.rounded_bl(corner).border_r_1())
+                        .border_color(theme.sidebar_border)
+                        .child(self.render_vault_sidebar(contents, cx)),
+                )
+            })
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .min_h_0()
+                    .when(!compact, gpui::Styled::h_full)
+                    .child(self.render_vault_detail(contents, cx)),
+            )
+    }
+
     fn render_unsealed(
         &self,
         contents: &VaultContents,
         errors: (Option<&str>, Option<&str>),
         browser_height: gpui::Pixels,
+        compact: bool,
         cx: &mut Context<Self>,
     ) -> Div {
         let theme = cx.theme().clone();
         let (contents_error, error) = errors;
-        let transfer_selected = matches!(
-            self.selected_vault_item.as_ref(),
-            Some(VaultSelection::Import | VaultSelection::Export)
-        );
         let header_title = self.render_vault_breadcrumb(cx);
         v_flex()
             .gap_5()
@@ -2313,6 +2371,7 @@ impl DesktopView {
                 h_flex()
                     .w_full()
                     .items_end()
+                    .flex_wrap()
                     .justify_between()
                     .gap_4()
                     .child(
@@ -2352,37 +2411,7 @@ impl DesktopView {
                             ),
                     ),
             )
-            .child(
-                h_flex()
-                    .w_full()
-                    .h(browser_height)
-                    .rounded_xl()
-                    .border_1()
-                    .border_color(theme.border)
-                    .overflow_hidden()
-                    .bg(theme.popover)
-                    .when(!transfer_selected, |workspace| {
-                        workspace.child(
-                            div()
-                                .w(px(232.))
-                                .flex_none()
-                                .h_full()
-                                .pl_5()
-                                .py_5()
-                                .bg(theme.sidebar)
-                                .border_r_1()
-                                .border_color(theme.sidebar_border)
-                                .child(self.render_vault_sidebar(contents, cx)),
-                        )
-                    })
-                    .child(
-                        div()
-                            .flex_1()
-                            .min_w_0()
-                            .h_full()
-                            .child(self.render_vault_detail(contents, cx)),
-                    ),
-            )
+            .child(self.render_vault_workspace(contents, browser_height, compact, cx))
             .when_some(contents_error.map(str::to_owned), |element, error| {
                 element.child(
                     div()
@@ -2411,7 +2440,8 @@ impl DesktopView {
                     h_flex()
                         .id("unsealed-control")
                         .flex_none()
-                        .items_center()
+                        .h_10()
+                        .items_stretch()
                         .rounded_lg()
                         .border_1()
                         .border_color(theme.border)
@@ -2426,7 +2456,13 @@ impl DesktopView {
                                 .text_color(theme.muted_foreground)
                                 .text_sm()
                                 .font_semibold()
-                                .child(div().w(px(8.)).h(px(8.)).rounded_full().bg(theme.success))
+                                .child(
+                                    div()
+                                        .w(rems(8. / 16.))
+                                        .h(rems(8. / 16.))
+                                        .rounded_full()
+                                        .bg(theme.success),
+                                )
                                 .child("Vault is unsealed")
                                 .tooltip(move |window, cx| {
                                     Tooltip::new(tooltip.clone()).build(window, cx)
@@ -2442,6 +2478,8 @@ impl DesktopView {
                                 .border_l_1()
                                 .border_color(theme.border)
                                 .bg(theme.muted)
+                                .rounded_tr(crate::appearance::rem_size(cx) * 0.5 - px(1.))
+                                .rounded_br(crate::appearance::rem_size(cx) * 0.5 - px(1.))
                                 .text_sm()
                                 .font_semibold()
                                 .child("Seal now")
@@ -2554,7 +2592,27 @@ impl DesktopView {
             )
     }
 
-    fn render_body(&self, browser_height: gpui::Pixels, cx: &mut Context<Self>) -> Div {
+    fn render_settings_button(&self, cx: &mut Context<Self>) -> Button {
+        Button::new("open-settings")
+            .h_10()
+            .icon(gpui_component::Icon::new(IconName::Settings).text_color(cx.theme().foreground))
+            .label("Settings")
+            .selected(self.settings_open)
+            .on_click(cx.listener(|view, _, _, cx| {
+                view.settings_open = !view.settings_open;
+                cx.notify();
+            }))
+    }
+
+    fn render_body(
+        &self,
+        browser_height: gpui::Pixels,
+        compact: bool,
+        cx: &mut Context<Self>,
+    ) -> Div {
+        if self.settings_open {
+            return div().w_full().child(self.settings.clone());
+        }
         let theme = cx.theme().clone();
         match &self.snapshot {
             Snapshot::Uninitialized { error } => self.render_uninitialized(error.as_deref(), cx),
@@ -2622,6 +2680,7 @@ impl DesktopView {
                 contents,
                 (contents_error.as_deref(), error.as_deref()),
                 browser_height,
+                compact,
                 cx,
             ),
             Snapshot::Error(error) => vault_card(&theme)
@@ -2638,23 +2697,35 @@ impl DesktopView {
     }
 }
 
+fn vault_browser_height(window: &Window, compact: bool, cx: &App) -> gpui::Pixels {
+    let scale = crate::appearance::scale(cx);
+    let available = window.viewport_size().height - px(272.) * scale;
+    let minimum = px(if compact { 500. } else { 320. }) * scale;
+    if available < minimum {
+        minimum
+    } else {
+        available
+    }
+}
+
 impl Render for DesktopView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        window.set_rem_size(crate::appearance::rem_size(cx));
         let theme = cx.theme().clone();
         let header_status = self.render_header_status(cx);
         let security_label = self.security_label();
-        let unsealed = matches!(self.snapshot, Snapshot::Unsealed { .. });
-        let body_max_width = match &self.snapshot {
-            Snapshot::Unsealed { .. } => 1200.,
-            Snapshot::Uninitialized { .. } => 520.,
-            _ => 440.,
-        };
-        let available_browser_height = window.viewport_size().height - px(272.);
-        let browser_height = if available_browser_height < px(320.) {
-            px(320.)
+        let unsealed = !self.settings_open && matches!(self.snapshot, Snapshot::Unsealed { .. });
+        let compact = window.viewport_size().width < px(800.) * crate::appearance::scale(cx);
+        let body_max_width = if self.settings_open {
+            1040.
         } else {
-            available_browser_height
+            match &self.snapshot {
+                Snapshot::Unsealed { .. } => 1200.,
+                Snapshot::Uninitialized { .. } => 520.,
+                _ => 440.,
+            }
         };
+        let browser_height = vault_browser_height(window, compact, cx);
         v_flex()
             .size_full()
             .px_6()
@@ -2666,7 +2737,9 @@ impl Render for DesktopView {
                 h_flex()
                     .w_full()
                     .flex_none()
-                    .h(px(80.))
+                    .min_h(rems(80. / 16.))
+                    .py_3()
+                    .flex_wrap()
                     .items_center()
                     .justify_between()
                     .gap_4()
@@ -2677,9 +2750,20 @@ impl Render for DesktopView {
                             .items_center()
                             .gap_2()
                             .child(brand_mark(36., theme.foreground))
-                            .child(div().text_size(px(23.)).font_semibold().child("FactorSeal")),
+                            .child(
+                                div()
+                                    .text_size(rems(23. / 16.))
+                                    .font_semibold()
+                                    .child("FactorSeal"),
+                            ),
                     )
-                    .when_some(header_status, gpui::ParentElement::child),
+                    .child(
+                        h_flex()
+                            .gap_2()
+                            .items_center()
+                            .when_some(header_status, gpui::ParentElement::child)
+                            .child(self.render_settings_button(cx)),
+                    ),
             )
             .child(
                 div()
@@ -2694,13 +2778,13 @@ impl Render for DesktopView {
                             .py_8()
                             .flex()
                             .justify_center()
-                            .when(!unsealed, gpui::Styled::items_center)
+                            .when(!unsealed && !self.settings_open, gpui::Styled::items_center)
                             .child(
                                 div()
                                     .w_full()
-                                    .max_w(px(body_max_width))
+                                    .max_w(rems(body_max_width / 16.))
                                     .flex_none()
-                                    .child(self.render_body(browser_height, cx)),
+                                    .child(self.render_body(browser_height, compact, cx)),
                             ),
                     )
                     .overflow_y_scrollbar(),
@@ -2709,7 +2793,7 @@ impl Render for DesktopView {
                 h_flex()
                     .w_full()
                     .flex_none()
-                    .h(px(48.))
+                    .h(rems(48. / 16.))
                     .items_center()
                     .justify_between()
                     .gap_4()
@@ -2741,19 +2825,12 @@ fn forget_desktop_window(handle: AnyWindowHandle, cx: &mut App) -> bool {
 }
 
 fn apply_desktop_snapshot(snapshot: &Snapshot, cx: &mut App) {
-    let window_height = desired_window_height(snapshot, cx);
-    let (handle, view_holder) = {
+    let view_holder = {
         let desktop = cx.global_mut::<DesktopWindow>();
         desktop.snapshot = snapshot.clone();
         desktop.refresh_generation = desktop.refresh_generation.wrapping_add(1);
-        (desktop.handle, Arc::clone(&desktop.view))
+        Arc::clone(&desktop.view)
     };
-
-    if let Some(handle) = handle {
-        let _ = handle.update(cx, |_, window, _| {
-            window.resize(size(px(1040.), window_height));
-        });
-    }
     if let Ok(holder) = view_holder.lock()
         && let Some(view) = holder.as_ref()
     {
@@ -3000,6 +3077,7 @@ pub(crate) fn setup(
 ) {
     gpui_component::init(cx);
     theming::initialize(cx);
+    crate::appearance::use_launch_lease(config.lease, cx);
     cx.on_action(open_desktop);
     cx.on_action(close_desktop);
     cx.on_action(toggle_desktop);

--- a/factorseal-desktop/src/app.rs
+++ b/factorseal-desktop/src/app.rs
@@ -598,6 +598,13 @@ impl DesktopView {
         cx: &mut Context<Self>,
     ) -> Self {
         let settings = cx.new(|cx| crate::settings_view::SettingsView::new(window, cx));
+        let settings_back = cx.subscribe(
+            &settings,
+            |view, _, _: &crate::settings_view::BackToVault, cx| {
+                view.settings_open = false;
+                cx.notify();
+            },
+        );
         let selected_group = snapshot
             .metadata()
             .map(|metadata| metadata.preferred_unlock_group().clone());
@@ -672,7 +679,7 @@ impl DesktopView {
             transfer_plaintext_confirmed: false,
             transfer_notice: None,
             system_integrations_expanded: false,
-            _subscriptions: vec![password_submit, vault_search_change],
+            _subscriptions: vec![password_submit, vault_search_change, settings_back],
         }
     }
 
@@ -2592,14 +2599,13 @@ impl DesktopView {
             )
     }
 
-    fn render_settings_button(&self, cx: &mut Context<Self>) -> Button {
+    fn render_settings_button(cx: &mut Context<Self>) -> Button {
         Button::new("open-settings")
             .h_10()
             .icon(gpui_component::Icon::new(IconName::Settings).text_color(cx.theme().foreground))
             .label("Settings")
-            .selected(self.settings_open)
             .on_click(cx.listener(|view, _, _, cx| {
-                view.settings_open = !view.settings_open;
+                view.settings_open = true;
                 cx.notify();
             }))
     }
@@ -2717,7 +2723,7 @@ impl Render for DesktopView {
         let unsealed = !self.settings_open && matches!(self.snapshot, Snapshot::Unsealed { .. });
         let compact = window.viewport_size().width < px(800.) * crate::appearance::scale(cx);
         let body_max_width = if self.settings_open {
-            1040.
+            1200.
         } else {
             match &self.snapshot {
                 Snapshot::Unsealed { .. } => 1200.,
@@ -2762,7 +2768,9 @@ impl Render for DesktopView {
                             .gap_2()
                             .items_center()
                             .when_some(header_status, gpui::ParentElement::child)
-                            .child(self.render_settings_button(cx)),
+                            .when(!self.settings_open, |element| {
+                                element.child(Self::render_settings_button(cx))
+                            }),
                     ),
             )
             .child(

--- a/factorseal-desktop/src/appearance.rs
+++ b/factorseal-desktop/src/appearance.rs
@@ -1,0 +1,303 @@
+use std::path::PathBuf;
+
+use anyhow::{Context as _, Result};
+use gpui::{App, Global, Hsla};
+use gpui_component::theme::{Theme, ThemeMode};
+use native_theme::theme::ColorMode;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum Choice {
+    #[default]
+    #[serde(rename = "factorseal")]
+    FactorSeal,
+    System,
+    OneDark,
+    Dracula,
+    SolarizedLight,
+    SolarizedDark,
+    Nord,
+    CatppuccinMocha,
+    GruvboxLight,
+    GruvboxDark,
+    OneLight,
+    DraculaLight,
+    NordLight,
+    TokyoNight,
+    TokyoNightDay,
+    CatppuccinLatte,
+    CatppuccinFrappe,
+    CatppuccinMacchiato,
+}
+
+impl Choice {
+    pub(crate) fn all() -> impl Iterator<Item = Self> {
+        [
+            Self::FactorSeal,
+            Self::System,
+            Self::GruvboxLight,
+            Self::GruvboxDark,
+            Self::OneLight,
+            Self::OneDark,
+            Self::DraculaLight,
+            Self::Dracula,
+            Self::SolarizedLight,
+            Self::SolarizedDark,
+            Self::NordLight,
+            Self::Nord,
+            Self::TokyoNightDay,
+            Self::TokyoNight,
+            Self::CatppuccinLatte,
+            Self::CatppuccinFrappe,
+            Self::CatppuccinMacchiato,
+            Self::CatppuccinMocha,
+        ]
+        .into_iter()
+    }
+
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::FactorSeal => "FactorSeal",
+            Self::System => "System",
+            Self::GruvboxLight => "Gruvbox Light",
+            Self::GruvboxDark => "Gruvbox Dark",
+            Self::OneLight => "One Light",
+            Self::OneDark => "One Dark",
+            Self::DraculaLight => "Dracula Light",
+            Self::Dracula => "Dracula",
+            Self::SolarizedLight => "Solarized Light",
+            Self::SolarizedDark => "Solarized Dark",
+            Self::NordLight => "Nord Light",
+            Self::Nord => "Nord",
+            Self::TokyoNightDay => "Tokyo Night Day",
+            Self::TokyoNight => "Tokyo Night",
+            Self::CatppuccinLatte => "Catppuccin Latte",
+            Self::CatppuccinFrappe => "Catppuccin Frappé",
+            Self::CatppuccinMacchiato => "Catppuccin Macchiato",
+            Self::CatppuccinMocha => "Catppuccin Mocha",
+        }
+    }
+
+    fn preset(self) -> Option<(&'static str, ColorMode)> {
+        match self {
+            Self::FactorSeal | Self::System => None,
+            Self::GruvboxLight => Some(("gruvbox", ColorMode::Light)),
+            Self::GruvboxDark => Some(("gruvbox", ColorMode::Dark)),
+            Self::OneLight => Some(("one-dark", ColorMode::Light)),
+            Self::OneDark => Some(("one-dark", ColorMode::Dark)),
+            Self::DraculaLight => Some(("dracula", ColorMode::Light)),
+            Self::Dracula => Some(("dracula", ColorMode::Dark)),
+            Self::SolarizedLight => Some(("solarized", ColorMode::Light)),
+            Self::SolarizedDark => Some(("solarized", ColorMode::Dark)),
+            Self::NordLight => Some(("nord", ColorMode::Light)),
+            Self::Nord => Some(("nord", ColorMode::Dark)),
+            Self::TokyoNightDay => Some(("tokyo-night", ColorMode::Light)),
+            Self::TokyoNight => Some(("tokyo-night", ColorMode::Dark)),
+            Self::CatppuccinLatte => Some(("catppuccin-latte", ColorMode::Light)),
+            Self::CatppuccinFrappe => Some(("catppuccin-frappe", ColorMode::Dark)),
+            Self::CatppuccinMacchiato => Some(("catppuccin-macchiato", ColorMode::Dark)),
+            Self::CatppuccinMocha => Some(("catppuccin-mocha", ColorMode::Dark)),
+        }
+    }
+}
+
+struct Preferences {
+    settings: crate::settings::DesktopSettings,
+    path: Option<PathBuf>,
+    system_theme: Theme,
+    system_input: Hsla,
+}
+
+impl Global for Preferences {}
+
+fn resolve(choice: Choice, system: &Theme, system_input: Hsla) -> Result<(Theme, Hsla)> {
+    let mut theme = system.clone();
+    let input = if let Some((preset, mode)) = choice.preset() {
+        let resolved = native_theme::theme::Theme::preset(preset)?
+            .resolve(mode)?
+            .variant;
+        theme.mode = if matches!(mode, ColorMode::Light) {
+            ThemeMode::Light
+        } else {
+            ThemeMode::Dark
+        };
+        crate::theming::apply_native_theme(&mut theme, &resolved);
+        theme.font_family = system.font_family.clone();
+        theme.font_size = system.font_size;
+        let color = resolved.input.background_color;
+        gpui::rgba(u32::from_be_bytes([color.r, color.g, color.b, color.a])).into()
+    } else if choice == Choice::FactorSeal {
+        crate::branding::apply(&mut theme);
+        crate::theming::sync_component_colors(&mut theme);
+        theme.input_background()
+    } else {
+        system_input
+    };
+    Ok((theme, input))
+}
+
+pub(crate) fn initialize(cx: &mut App) {
+    let path = crate::settings::path();
+    let settings = path
+        .as_deref()
+        .map_or_else(
+            || Ok(crate::settings::DesktopSettings::default()),
+            crate::settings::load,
+        )
+        .unwrap_or_else(|error| {
+            eprintln!("could not read desktop settings: {error:#}");
+            crate::settings::DesktopSettings::default()
+        });
+    cx.set_global(Preferences {
+        settings,
+        path,
+        system_theme: Theme::global(cx).clone(),
+        system_input: crate::theming::input_background(cx),
+    });
+    if let Err(error) = apply_selected(cx) {
+        eprintln!("could not apply desktop theme: {error:#}");
+    }
+}
+
+fn apply_selected(cx: &mut App) -> Result<()> {
+    let preferences = cx.global::<Preferences>();
+    let (mut theme, input) = resolve(
+        preferences.settings.theme,
+        &preferences.system_theme,
+        preferences.system_input,
+    )?;
+    let settings = &preferences.settings;
+    if let Some(font) = &settings.font {
+        theme.font_family = font.clone().into();
+    }
+    if let Some(size) = settings.text_size {
+        theme.font_size = gpui::px(f32::from(size));
+    }
+    theme.font_size *= f32::from(settings.ui_scale) / 100.;
+    let reduced_motion = settings.reduced_motion;
+    *Theme::global_mut(cx) = theme;
+    cx.set_reduce_motion(reduced_motion);
+    crate::theming::set_input_background(input, cx);
+    Theme::sync_base(cx);
+    crate::app::refresh_tray_icon(cx);
+    cx.refresh_windows();
+    Ok(())
+}
+
+pub(crate) fn current(cx: &App) -> &crate::settings::DesktopSettings {
+    &cx.global::<Preferences>().settings
+}
+
+pub(crate) fn use_launch_lease(lease: crate::runtime::LeasePolicy, cx: &mut App) {
+    let settings = &mut cx.global_mut::<Preferences>().settings;
+    settings.idle_seconds = lease.idle_timeout.as_secs();
+    settings.maximum_seconds = lease.maximum_lifetime.as_secs();
+}
+
+pub(crate) fn scale(cx: &App) -> f32 {
+    f32::from(current(cx).ui_scale) / 100.
+}
+
+pub(crate) fn rem_size(cx: &App) -> gpui::Pixels {
+    let preferences = cx.global::<Preferences>();
+    let text_scale = preferences.settings.text_size.map_or(1., |size| {
+        f32::from(size) / f32::from(preferences.system_theme.font_size)
+    });
+    gpui::px(16. * scale(cx) * text_scale)
+}
+
+pub(crate) fn update(settings: crate::settings::DesktopSettings, cx: &mut App) -> Result<()> {
+    let preferences = cx.global::<Preferences>();
+    let security_changed = preferences.settings.idle_seconds != settings.idle_seconds
+        || preferences.settings.maximum_seconds != settings.maximum_seconds;
+    resolve(
+        settings.theme,
+        &preferences.system_theme,
+        preferences.system_input,
+    )?;
+    let path = preferences
+        .path
+        .as_deref()
+        .context("desktop configuration directory is unavailable")?;
+    crate::settings::save(path, &settings)?;
+    if security_changed {
+        crate::app::set_next_lease(
+            crate::runtime::lease_policy(settings.idle_seconds, settings.maximum_seconds)
+                .map_err(anyhow::Error::msg)?,
+            cx,
+        );
+    }
+    cx.global_mut::<Preferences>().settings = settings;
+    apply_selected(cx)
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn system_changed(cx: &mut App) {
+    let theme = Theme::global(cx).clone();
+    let input = crate::theming::input_background(cx);
+    let preferences = cx.global_mut::<Preferences>();
+    preferences.system_theme = theme;
+    preferences.system_input = input;
+    if let Err(error) = apply_selected(cx) {
+        eprintln!("could not refresh desktop theme: {error:#}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn additional_bundled_variants_have_distinct_palettes() {
+        for preset in ["gruvbox", "one-dark", "dracula", "nord", "tokyo-night"] {
+            let theme = native_theme::theme::Theme::preset(preset).unwrap();
+            let light = theme.resolve(ColorMode::Light).unwrap().variant;
+            let dark = theme.resolve(ColorMode::Dark).unwrap().variant;
+            assert_ne!(
+                light.window.background_color, dark.window.background_color,
+                "{preset}"
+            );
+            assert_ne!(
+                light.defaults.text_color, dark.defaults.text_color,
+                "{preset}"
+            );
+        }
+        for (preset, mode) in [
+            ("catppuccin-latte", ColorMode::Light),
+            ("catppuccin-frappe", ColorMode::Dark),
+            ("catppuccin-macchiato", ColorMode::Dark),
+        ] {
+            let theme = native_theme::theme::Theme::preset(preset)
+                .unwrap()
+                .resolve(mode)
+                .unwrap()
+                .variant;
+            assert_ne!(
+                theme.window.background_color, theme.defaults.text_color,
+                "{preset}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_theme_resolves_and_system_colors_are_restored() {
+        let system = Theme {
+            colors: gpui_component::ThemeColor {
+                background: gpui::rgb(0x0012_3456).into(),
+                ..Theme::default().colors
+            },
+            ..Theme::default()
+        };
+        let input = gpui::rgb(0x0065_4321).into();
+        for choice in Choice::all() {
+            let (theme, _) = resolve(choice, &system, input).unwrap();
+            assert_eq!(
+                theme.tokens.button_primary.background,
+                theme.button_primary.into()
+            );
+            let (restored, restored_input) = resolve(Choice::System, &system, input).unwrap();
+            assert_eq!(restored.background, system.background);
+            assert_eq!(restored_input, input);
+        }
+    }
+}

--- a/factorseal-desktop/src/branding.rs
+++ b/factorseal-desktop/src/branding.rs
@@ -1,4 +1,4 @@
-use gpui::{App, Hsla, px, rgb};
+use gpui::{Hsla, px, rgb};
 use gpui_component::{scroll::ScrollbarMode, theme::Theme};
 
 pub(crate) const MARK_ASSET: &str = "factorseal-mark.svg";
@@ -59,9 +59,8 @@ fn color(hex: u32) -> Hsla {
 /// We retain the system light/dark preference and typography, then replace the
 /// visual tokens so the application remains recognizably `FactorSeal` on every
 /// desktop environment.
-pub(crate) fn apply(cx: &mut App) {
-    let dark = Theme::global(cx).is_dark();
-    let theme = Theme::global_mut(cx);
+pub(crate) fn apply(theme: &mut Theme) {
+    let dark = theme.is_dark();
     let palette = if dark { DARK } else { LIGHT };
     let Palette {
         canvas,

--- a/factorseal-desktop/src/main.rs
+++ b/factorseal-desktop/src/main.rs
@@ -1,8 +1,11 @@
 mod app;
+mod appearance;
 mod branding;
 mod instance;
 mod runtime;
 mod secret_input;
+mod settings;
+mod settings_view;
 mod theming;
 mod timing;
 
@@ -76,12 +79,12 @@ struct Args {
     keyring_activation: bool,
 
     /// Idle seconds before hardware-unwrapped keys are discarded.
-    #[arg(long, env = "FACTORSEAL_IDLE_SECONDS", default_value_t = 300)]
-    idle_seconds: u64,
+    #[arg(long, env = "FACTORSEAL_IDLE_SECONDS")]
+    idle_seconds: Option<u64>,
 
     /// Absolute maximum seconds for one unseal lease.
-    #[arg(long, env = "FACTORSEAL_MAXIMUM_SECONDS", default_value_t = 28_800)]
-    maximum_seconds: u64,
+    #[arg(long, env = "FACTORSEAL_MAXIMUM_SECONDS")]
+    maximum_seconds: Option<u64>,
 }
 
 fn main() {
@@ -104,11 +107,23 @@ fn main() {
         eprintln!("factorseal-desktop: {error}");
         std::process::exit(1);
     });
-    let lease =
-        runtime::lease_policy(args.idle_seconds, args.maximum_seconds).unwrap_or_else(|error| {
-            eprintln!("factorseal-desktop: {error}");
-            std::process::exit(1);
+    let saved = settings::path()
+        .map_or_else(
+            || Ok(settings::DesktopSettings::default()),
+            |path| settings::load(&path),
+        )
+        .unwrap_or_else(|error| {
+            eprintln!("could not read desktop settings: {error:#}");
+            settings::DesktopSettings::default()
         });
+    let lease = runtime::lease_policy(
+        args.idle_seconds.unwrap_or(saved.idle_seconds),
+        args.maximum_seconds.unwrap_or(saved.maximum_seconds),
+    )
+    .unwrap_or_else(|error| {
+        eprintln!("factorseal-desktop: {error}");
+        std::process::exit(1);
+    });
     let config = runtime::RuntimeConfig {
         root,
         socket: args.socket,

--- a/factorseal-desktop/src/runtime.rs
+++ b/factorseal-desktop/src/runtime.rs
@@ -104,6 +104,7 @@ impl Snapshot {
 
 pub(crate) struct DesktopRuntime {
     config: RuntimeConfig,
+    next_lease: Mutex<LeasePolicy>,
     events: smol::channel::Sender<Snapshot>,
     lifeline: Mutex<Option<std::process::ChildStdin>>,
     unlock_in_progress: AtomicBool,
@@ -114,6 +115,7 @@ impl DesktopRuntime {
         let (events, receiver) = smol::channel::bounded(16);
         (
             Arc::new(Self {
+                next_lease: Mutex::new(config.lease),
                 config,
                 events,
                 lifeline: Mutex::new(None),
@@ -154,6 +156,12 @@ impl DesktopRuntime {
                 error: None,
             },
             Err(error) => Snapshot::Uninitialized { error: Some(error) },
+        }
+    }
+
+    pub(crate) fn set_next_lease(&self, lease: LeasePolicy) {
+        if let Ok(mut next) = self.next_lease.lock() {
+            *next = lease;
         }
     }
 
@@ -508,20 +516,28 @@ impl DesktopRuntime {
         Ok(worker)
     }
 
+    fn unlock_operation(
+        &self,
+        group: UnlockGroup,
+    ) -> Result<factorseal::desktop_worker::Operation, String> {
+        let lease = *self
+            .next_lease
+            .lock()
+            .map_err(|_| "desktop lease lock is unavailable".to_owned())?;
+        Ok(factorseal::desktop_worker::Operation::Unlock {
+            group,
+            idle_seconds: lease.idle_timeout.as_secs(),
+            maximum_seconds: lease.maximum_lifetime.as_secs(),
+        })
+    }
+
     fn supervise_worker(
         &self,
         metadata: &VaultMetadata,
         group: UnlockGroup,
         password: Zeroizing<Vec<u8>>,
     ) -> Result<(), String> {
-        let mut worker = self.spawn_worker(
-            factorseal::desktop_worker::Operation::Unlock {
-                group,
-                idle_seconds: self.config.lease.idle_timeout.as_secs(),
-                maximum_seconds: self.config.lease.maximum_lifetime.as_secs(),
-            },
-            password,
-        )?;
+        let mut worker = self.spawn_worker(self.unlock_operation(group)?, password)?;
         worker.read_ready()?;
         let deadline = std::time::Instant::now() + Duration::from_secs(10);
         let (idle_deadline, absolute_deadline) = loop {
@@ -844,6 +860,35 @@ mod tests {
     #[cfg(target_os = "linux")]
     use super::factorseal_secret_service;
     use super::load_vault_contents;
+
+    #[test]
+    fn lease_changes_preserve_the_captured_unlock_policy() {
+        let directory = tempfile::tempdir().unwrap();
+        let (runtime, _) = super::DesktopRuntime::new(super::RuntimeConfig {
+            root: directory.path().to_path_buf(),
+            socket: None,
+            lease: super::lease_policy(300, 28_800).unwrap(),
+        });
+        let group = factorseal::UnlockGroup::new([factorseal::UnlockFactorKind::Password]).unwrap();
+        let captured = runtime.unlock_operation(group.clone()).unwrap();
+        runtime.set_next_lease(super::lease_policy(60, 3600).unwrap());
+        let next = runtime.unlock_operation(group.clone()).unwrap();
+        for (operation, expected_idle, expected_maximum) in
+            [(captured, 300, 28_800), (next, 60, 3600)]
+        {
+            let factorseal::desktop_worker::Operation::Unlock {
+                group: worker_group,
+                idle_seconds,
+                maximum_seconds,
+            } = operation
+            else {
+                panic!("expected an unlock operation");
+            };
+            assert_eq!(worker_group, group);
+            assert_eq!(idle_seconds, expected_idle);
+            assert_eq!(maximum_seconds, expected_maximum);
+        }
+    }
 
     #[cfg(target_os = "linux")]
     #[test]

--- a/factorseal-desktop/src/settings.rs
+++ b/factorseal-desktop/src/settings.rs
@@ -1,0 +1,155 @@
+use std::{
+    io::Write as _,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context as _, Result, ensure};
+use serde::{Deserialize, Serialize};
+
+use crate::appearance::Choice;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub(crate) struct DesktopSettings {
+    pub(crate) theme: Choice,
+    pub(crate) ui_scale: u16,
+    pub(crate) text_size: Option<u16>,
+    pub(crate) font: Option<String>,
+    pub(crate) reduced_motion: bool,
+    pub(crate) idle_seconds: u64,
+    pub(crate) maximum_seconds: u64,
+}
+
+impl Default for DesktopSettings {
+    fn default() -> Self {
+        Self {
+            theme: Choice::default(),
+            ui_scale: 100,
+            text_size: None,
+            font: None,
+            reduced_motion: false,
+            idle_seconds: 300,
+            maximum_seconds: 28_800,
+        }
+    }
+}
+
+impl DesktopSettings {
+    pub(crate) fn validate(&self) -> Result<()> {
+        ensure!(
+            (80..=200).contains(&self.ui_scale),
+            "UI scale is outside the supported range"
+        );
+        ensure!(
+            self.text_size.is_none_or(|size| (12..=24).contains(&size)),
+            "text size is outside the supported range"
+        );
+        ensure!(
+            self.font
+                .as_ref()
+                .is_none_or(|font| !font.trim().is_empty()),
+            "font name is empty"
+        );
+        crate::runtime::lease_policy(self.idle_seconds, self.maximum_seconds)
+            .map_err(anyhow::Error::msg)?;
+        Ok(())
+    }
+}
+
+pub(crate) fn path() -> Option<PathBuf> {
+    directories::ProjectDirs::from("dev", "Factorseal", "Factorseal")
+        .map(|dirs| dirs.config_dir().join("preferences.json"))
+}
+
+pub(crate) fn load(path: &Path) -> Result<DesktopSettings> {
+    for candidate in [path.to_path_buf(), path.with_file_name("desktop.json")] {
+        match std::fs::read(candidate) {
+            Ok(contents) => {
+                let settings: DesktopSettings = serde_json::from_slice(&contents)?;
+                settings.validate()?;
+                return Ok(settings);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    let settings = match std::fs::read(path.with_file_name("desktop-theme.json")) {
+        Ok(contents) => DesktopSettings {
+            theme: serde_json::from_slice(&contents)?,
+            ..DesktopSettings::default()
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => DesktopSettings::default(),
+        Err(error) => return Err(error.into()),
+    };
+    settings.validate()?;
+    Ok(settings)
+}
+
+pub(crate) fn save(path: &Path, settings: &DesktopSettings) -> Result<()> {
+    settings.validate()?;
+    let parent = path
+        .parent()
+        .context("desktop settings path has no parent")?;
+    std::fs::create_dir_all(parent)?;
+    let mut file = tempfile::NamedTempFile::new_in(parent)?;
+    file.write_all(&serde_json::to_vec_pretty(settings)?)?;
+    file.as_file().sync_all()?;
+    file.persist(path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_existing_theme_ids_remain_compatible() {
+        for choice in Choice::all() {
+            let directory = tempfile::tempdir().unwrap();
+            let path = directory.path().join("preferences.json");
+            let settings = DesktopSettings {
+                theme: choice,
+                ..DesktopSettings::default()
+            };
+            save(&path, &settings).unwrap();
+            assert_eq!(load(&path).unwrap(), settings);
+        }
+    }
+
+    #[test]
+    fn migrates_theme_and_round_trips_all_settings() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("preferences.json");
+        assert_eq!(load(&path).unwrap(), DesktopSettings::default());
+        std::fs::write(
+            path.with_file_name("desktop-theme.json"),
+            "\"gruvbox-dark\"",
+        )
+        .unwrap();
+        assert_eq!(load(&path).unwrap().theme, Choice::GruvboxDark);
+        let settings = DesktopSettings {
+            theme: Choice::Dracula,
+            ui_scale: 150,
+            text_size: Some(20),
+            font: Some("Ubuntu Sans".to_owned()),
+            reduced_motion: true,
+            idle_seconds: 60,
+            maximum_seconds: 3600,
+        };
+        save(&path.with_file_name("desktop.json"), &settings).unwrap();
+        assert_eq!(load(&path).unwrap(), settings);
+        save(&path, &settings).unwrap();
+        save(
+            &path.with_file_name("desktop.json"),
+            &DesktopSettings::default(),
+        )
+        .unwrap();
+        assert_eq!(load(&path).unwrap(), settings);
+        let invalid = DesktopSettings {
+            idle_seconds: 7200,
+            ..settings.clone()
+        };
+        assert!(save(&path, &invalid).is_err());
+        assert_eq!(load(&path).unwrap(), settings);
+    }
+}

--- a/factorseal-desktop/src/settings_view.rs
+++ b/factorseal-desktop/src/settings_view.rs
@@ -1,9 +1,8 @@
 use gpui::{
-    App, Context, Div, Entity, Render, SharedString, Subscription, Window, div, prelude::*, px,
-    rems,
+    App, Context, Div, Entity, Render, SharedString, Subscription, Window, div, prelude::*, rems,
 };
 use gpui_component::{
-    ActiveTheme as _, IndexPath, Selectable as _, StyledExt as _,
+    ActiveTheme as _, IndexPath, Selectable as _, Sizable as _, StyledExt as _,
     button::Button,
     h_flex,
     select::{Select, SelectEvent, SelectItem, SelectState},
@@ -97,6 +96,10 @@ pub(crate) struct SettingsView {
     error: Option<&'static str>,
     _subscriptions: Vec<Subscription>,
 }
+
+pub(crate) struct BackToVault;
+
+impl gpui::EventEmitter<BackToVault> for SettingsView {}
 
 fn values(settings: &DesktopSettings) -> [Value; 6] {
     [
@@ -274,8 +277,7 @@ impl SettingsView {
 }
 
 impl Render for SettingsView {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let compact = window.viewport_size().width < px(900.) * appearance::scale(cx);
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let section = self.section;
         let content = if section == Section::Appearance {
             self.appearance(cx)
@@ -283,80 +285,75 @@ impl Render for SettingsView {
             self.security(cx)
         };
         let theme = cx.theme();
-        h_flex()
+        v_flex()
             .w_full()
             .min_w_0()
-            .gap_6()
-            .items_start()
-            .when(compact, gpui::Styled::flex_col)
+            .gap_5()
             .child(
-                v_flex()
-                    .w(rems(12.))
-                    .flex_none()
-                    .gap_2()
-                    .p_4()
-                    .rounded_lg()
-                    .bg(theme.sidebar)
-                    .when(compact, gpui::Styled::w_full)
+                h_flex()
+                    .w_full()
+                    .items_end()
+                    .justify_between()
+                    .flex_wrap()
+                    .gap_4()
                     .child(
                         h_flex()
-                            .gap_2()
                             .items_center()
-                            .mb_3()
+                            .gap_2()
+                            .text_2xl()
+                            .font_semibold()
                             .child(
-                                gpui_component::Icon::new(gpui_component::IconName::Settings)
-                                    .text_color(theme.foreground),
+                                div()
+                                    .id("settings-vault-breadcrumb")
+                                    .cursor_pointer()
+                                    .hover(|style| style.text_color(theme.muted_foreground))
+                                    .child("Your vault")
+                                    .on_click(cx.listener(|_, _, _, cx| cx.emit(BackToVault))),
                             )
-                            .child(div().text_lg().font_semibold().child("Settings")),
+                            .child(div().text_color(theme.muted_foreground).child("←"))
+                            .child("Settings"),
                     )
-                    .children(
-                        [
-                            (
-                                Section::Appearance,
-                                "Appearance",
-                                gpui_component::Icon::new(gpui_component::IconName::Palette),
-                            ),
-                            (
-                                Section::Security,
-                                "Security",
-                                gpui_component::Icon::default()
-                                    .path(crate::branding::MICRO_MARK_ASSET),
-                            ),
-                        ]
-                        .into_iter()
-                        .map(|(section, label, icon)| {
-                            Button::new(label)
-                                .icon(icon.text_color(theme.foreground))
-                                .justify_start()
-                                .label(label)
-                                .w_full()
-                                .selected(self.section == section)
-                                .on_click(cx.listener(move |view, _, _, cx| {
-                                    view.section = section;
-                                    view.error = None;
-                                    cx.notify();
-                                }))
-                        }),
+                    .child(
+                        h_flex().id("settings-tabs").gap_2().children(
+                            [
+                                (Section::Appearance, "Appearance"),
+                                (Section::Security, "Security"),
+                            ]
+                            .into_iter()
+                            .map(|(section, label)| {
+                                Button::new(label)
+                                    .small()
+                                    .label(label)
+                                    .selected(self.section == section)
+                                    .on_click(cx.listener(move |view, _, _, cx| {
+                                        view.section = section;
+                                        view.error = None;
+                                        cx.notify();
+                                    }))
+                            }),
+                        ),
                     ),
             )
             .child(
-                v_flex()
-                    .flex_1()
-                    .min_w_0()
+                div()
                     .w_full()
-                    .gap_4()
-                    .py_4()
-                    .child(div().text_2xl().font_semibold().child(
-                        if section == Section::Appearance {
-                            "Appearance"
-                        } else {
-                            "Security"
-                        },
-                    ))
-                    .child(content)
-                    .when_some(self.error, |view, error| {
-                        view.child(div().text_color(theme.danger).child(error))
-                    }),
+                    .rounded_xl()
+                    .border_1()
+                    .border_color(theme.border)
+                    .overflow_hidden()
+                    .bg(theme.popover)
+                    .child(
+                        v_flex()
+                            .w_full()
+                            .min_w_0()
+                            .max_w(rems(820. / 16.))
+                            .gap_4()
+                            .p_6()
+                            .child(content)
+                            .when_some(self.error, |view, error| {
+                                view.child(div().text_color(theme.danger).child(error))
+                            }),
+                    ),
             )
     }
 }

--- a/factorseal-desktop/src/settings_view.rs
+++ b/factorseal-desktop/src/settings_view.rs
@@ -1,0 +1,362 @@
+use gpui::{
+    App, Context, Div, Entity, Render, SharedString, Subscription, Window, div, prelude::*, px,
+    rems,
+};
+use gpui_component::{
+    ActiveTheme as _, IndexPath, Selectable as _, StyledExt as _,
+    button::Button,
+    h_flex,
+    select::{Select, SelectEvent, SelectItem, SelectState},
+    switch::Switch,
+    v_flex,
+};
+
+use crate::{
+    appearance::{self, Choice},
+    settings::DesktopSettings,
+};
+
+#[derive(Clone, Debug, PartialEq)]
+enum Value {
+    Theme(Choice),
+    Scale(u16),
+    Text(Option<u16>),
+    Font(Option<String>),
+    Idle(u64),
+    Maximum(u64),
+}
+
+impl Value {
+    fn label(&self) -> SharedString {
+        match self {
+            Self::Theme(choice) => choice.label().into(),
+            Self::Scale(value) => format!("{value}%").into(),
+            Self::Text(Some(value)) => format!("{value} px").into(),
+            Self::Font(Some(value)) => value.clone().into(),
+            Self::Text(None) | Self::Font(None) => "System default".into(),
+            Self::Idle(seconds) | Self::Maximum(seconds) => {
+                if seconds.is_multiple_of(3600) {
+                    let hours = seconds / 3600;
+                    format!("{hours} {}", if hours == 1 { "hour" } else { "hours" }).into()
+                } else if seconds.is_multiple_of(60) {
+                    let minutes = seconds / 60;
+                    format!(
+                        "{minutes} {}",
+                        if minutes == 1 { "minute" } else { "minutes" }
+                    )
+                    .into()
+                } else {
+                    format!(
+                        "{} minutes",
+                        std::time::Duration::from_secs(*seconds).as_secs_f64() / 60.
+                    )
+                    .into()
+                }
+            }
+        }
+    }
+
+    fn apply(&self, settings: &mut DesktopSettings) {
+        match self {
+            Self::Theme(value) => settings.theme = *value,
+            Self::Scale(value) => settings.ui_scale = *value,
+            Self::Text(value) => settings.text_size = *value,
+            Self::Font(value) => settings.font.clone_from(value),
+            Self::Idle(value) => settings.idle_seconds = *value,
+            Self::Maximum(value) => settings.maximum_seconds = *value,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct Item(Value);
+
+impl SelectItem for Item {
+    type Value = Value;
+
+    fn title(&self) -> SharedString {
+        self.0.label()
+    }
+
+    fn value(&self) -> &Value {
+        &self.0
+    }
+}
+
+type Control = Entity<SelectState<Vec<Item>>>;
+
+#[derive(Clone, Copy, PartialEq)]
+enum Section {
+    Appearance,
+    Security,
+}
+
+pub(crate) struct SettingsView {
+    section: Section,
+    controls: Vec<Control>,
+    error: Option<&'static str>,
+    _subscriptions: Vec<Subscription>,
+}
+
+fn values(settings: &DesktopSettings) -> [Value; 6] {
+    [
+        Value::Theme(settings.theme),
+        Value::Scale(settings.ui_scale),
+        Value::Text(settings.text_size),
+        Value::Font(settings.font.clone()),
+        Value::Idle(settings.idle_seconds),
+        Value::Maximum(settings.maximum_seconds),
+    ]
+}
+
+fn options(cx: &App) -> [Vec<Value>; 6] {
+    let mut fonts = cx.text_system().all_font_names();
+    fonts.sort_unstable();
+    fonts.dedup();
+    [
+        Choice::all().map(Value::Theme).collect(),
+        [80, 90, 100, 110, 125, 150, 175, 200]
+            .into_iter()
+            .map(Value::Scale)
+            .collect(),
+        std::iter::once(Value::Text(None))
+            .chain(
+                [12, 14, 16, 18, 20, 24]
+                    .into_iter()
+                    .map(|size| Value::Text(Some(size))),
+            )
+            .collect(),
+        std::iter::once(Value::Font(None))
+            .chain(fonts.into_iter().map(|font| Value::Font(Some(font))))
+            .collect(),
+        [60, 300, 900, 1800, 3600]
+            .into_iter()
+            .map(Value::Idle)
+            .collect(),
+        [900, 3600, 14_400, 28_800, 86_400]
+            .into_iter()
+            .map(Value::Maximum)
+            .collect(),
+    ]
+}
+
+impl SettingsView {
+    pub(crate) fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let current = values(appearance::current(cx));
+        let controls: Vec<_> = options(cx)
+            .into_iter()
+            .zip(current)
+            .map(|(mut options, selected)| {
+                if !options.contains(&selected) {
+                    options.push(selected.clone());
+                }
+                let index = options
+                    .iter()
+                    .position(|value| value == &selected)
+                    .map(|index| IndexPath::default().row(index));
+                cx.new(|cx| {
+                    SelectState::new(
+                        options.into_iter().map(Item).collect::<Vec<_>>(),
+                        index,
+                        window,
+                        cx,
+                    )
+                    .searchable(true)
+                })
+            })
+            .collect();
+        let subscriptions = controls
+            .iter()
+            .map(|control| {
+                cx.subscribe_in(
+                    control,
+                    window,
+                    |view, _, event: &SelectEvent<Vec<Item>>, window, cx| {
+                        if let SelectEvent::Confirm(Some(value)) = event {
+                            let mut settings = appearance::current(cx).clone();
+                            value.apply(&mut settings);
+                            view.save(settings, window, cx);
+                        }
+                    },
+                )
+            })
+            .collect();
+        Self {
+            section: Section::Appearance,
+            controls,
+            error: None,
+            _subscriptions: subscriptions,
+        }
+    }
+
+    fn save(&mut self, settings: DesktopSettings, window: &mut Window, cx: &mut Context<Self>) {
+        self.error = if settings.idle_seconds > settings.maximum_seconds {
+            Some("Idle lock timeout must not exceed maximum unlock duration.")
+        } else if let Err(error) = appearance::update(settings, cx) {
+            eprintln!("could not save desktop settings: {error:#}");
+            Some("Could not save settings.")
+        } else {
+            None
+        };
+        if self.error.is_some() {
+            for (control, value) in self.controls.iter().zip(values(appearance::current(cx))) {
+                control.update(cx, |control, cx| {
+                    control.set_selected_value(&value, window, cx);
+                });
+            }
+        }
+        cx.notify();
+    }
+
+    fn row(&self, label: &'static str, index: usize, cx: &App) -> Div {
+        h_flex()
+            .w_full()
+            .items_center()
+            .justify_between()
+            .flex_wrap()
+            .gap_3()
+            .py_4()
+            .border_b_1()
+            .border_color(cx.theme().border)
+            .child(div().font_medium().child(label))
+            .child(
+                div().w(rems(18.)).max_w_full().flex_none().p_1().child(
+                    Select::new(&self.controls[index])
+                        .accessibility_label(label)
+                        .search_placeholder(label)
+                        .w_full(),
+                ),
+            )
+    }
+
+    fn appearance(&self, cx: &mut Context<Self>) -> Div {
+        v_flex()
+            .w_full()
+            .child(self.row("Theme", 0, cx))
+            .child(self.row("UI scale", 1, cx))
+            .child(self.row("Text size", 2, cx))
+            .child(self.row("Font", 3, cx))
+            .child(
+                h_flex()
+                    .w_full()
+                    .items_center()
+                    .justify_between()
+                    .gap_3()
+                    .py_4()
+                    .child("Reduced motion")
+                    .child(
+                        Switch::new("reduced-motion")
+                            .accessibility_label("Reduced motion")
+                            .checked(appearance::current(cx).reduced_motion)
+                            .on_click(cx.listener(|view, checked: &bool, window, cx| {
+                                let mut settings = appearance::current(cx).clone();
+                                settings.reduced_motion = *checked;
+                                view.save(settings, window, cx);
+                            })),
+                    ),
+            )
+    }
+
+    fn security(&self, cx: &App) -> Div {
+        v_flex()
+            .w_full()
+            .gap_2()
+            .child(self.row("Idle lock timeout", 4, cx))
+            .child(self.row("Maximum unlock duration", 5, cx))
+            .child(
+                div()
+                    .pt_3()
+                    .text_sm()
+                    .text_color(cx.theme().muted_foreground)
+                    .child("Applies the next time you unlock the vault."),
+            )
+    }
+}
+
+impl Render for SettingsView {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let compact = window.viewport_size().width < px(900.) * appearance::scale(cx);
+        let section = self.section;
+        let content = if section == Section::Appearance {
+            self.appearance(cx)
+        } else {
+            self.security(cx)
+        };
+        let theme = cx.theme();
+        h_flex()
+            .w_full()
+            .min_w_0()
+            .gap_6()
+            .items_start()
+            .when(compact, gpui::Styled::flex_col)
+            .child(
+                v_flex()
+                    .w(rems(12.))
+                    .flex_none()
+                    .gap_2()
+                    .p_4()
+                    .rounded_lg()
+                    .bg(theme.sidebar)
+                    .when(compact, gpui::Styled::w_full)
+                    .child(
+                        h_flex()
+                            .gap_2()
+                            .items_center()
+                            .mb_3()
+                            .child(
+                                gpui_component::Icon::new(gpui_component::IconName::Settings)
+                                    .text_color(theme.foreground),
+                            )
+                            .child(div().text_lg().font_semibold().child("Settings")),
+                    )
+                    .children(
+                        [
+                            (
+                                Section::Appearance,
+                                "Appearance",
+                                gpui_component::Icon::new(gpui_component::IconName::Palette),
+                            ),
+                            (
+                                Section::Security,
+                                "Security",
+                                gpui_component::Icon::default()
+                                    .path(crate::branding::MICRO_MARK_ASSET),
+                            ),
+                        ]
+                        .into_iter()
+                        .map(|(section, label, icon)| {
+                            Button::new(label)
+                                .icon(icon.text_color(theme.foreground))
+                                .justify_start()
+                                .label(label)
+                                .w_full()
+                                .selected(self.section == section)
+                                .on_click(cx.listener(move |view, _, _, cx| {
+                                    view.section = section;
+                                    view.error = None;
+                                    cx.notify();
+                                }))
+                        }),
+                    ),
+            )
+            .child(
+                v_flex()
+                    .flex_1()
+                    .min_w_0()
+                    .w_full()
+                    .gap_4()
+                    .py_4()
+                    .child(div().text_2xl().font_semibold().child(
+                        if section == Section::Appearance {
+                            "Appearance"
+                        } else {
+                            "Security"
+                        },
+                    ))
+                    .child(content)
+                    .when_some(self.error, |view, error| {
+                        view.child(div().text_color(theme.danger).child(error))
+                    }),
+            )
+    }
+}

--- a/factorseal-desktop/src/theming.rs
+++ b/factorseal-desktop/src/theming.rs
@@ -66,7 +66,6 @@ struct InputBackground(gpui::Hsla);
 
 impl Global for InputBackground {}
 
-#[cfg(target_os = "linux")]
 pub(crate) fn set_input_background(color: gpui::Hsla, cx: &mut App) {
     cx.set_global(InputBackground(color));
 }
@@ -144,10 +143,7 @@ pub(crate) fn initialize(cx: &mut App) {
         last_change_source: None,
     });
 
-    if cx.global::<ThemeState>().backend.is_none() {
-        crate::branding::apply(cx);
-        sync_component_colors(gpui_component::theme::Theme::global_mut(cx));
-    }
+    crate::appearance::initialize(cx);
 }
 
 #[cfg(target_os = "linux")]
@@ -191,6 +187,7 @@ fn refresh_native_theme(cx: &mut App) {
             state.backend = Some(backend);
             state.summary = summary;
             state.error = None;
+            crate::appearance::system_changed(cx);
         }
         Err(error) => {
             let state = cx.global_mut::<ThemeState>();
@@ -548,7 +545,7 @@ fn install_theme(loaded: &LoadedTheme, cx: &mut App) {
     let theme = Theme::global_mut(cx);
     apply_native_theme(theme, &loaded.resolved);
     let background = loaded.resolved.input.background_color;
-    set_input_background(
+    cx.set_global(InputBackground(
         gpui::rgba(u32::from_be_bytes([
             background.r,
             background.g,
@@ -556,12 +553,10 @@ fn install_theme(loaded: &LoadedTheme, cx: &mut App) {
             background.a,
         ]))
         .into(),
-        cx,
-    );
+    ));
     Theme::sync_base(cx);
 }
 
-#[cfg(target_os = "linux")]
 pub(crate) fn apply_native_theme(
     theme: &mut gpui_component::theme::Theme,
     native: &native_theme::theme::ResolvedTheme,


### PR DESCRIPTION
Add Appearance and Security settings with 18 theme choices, UI scale, text size, installed-font selection, reduced motion, idle lock timeout, and maximum unlock duration. Save preferences atomically and migrate the earlier desktop.json and desktop-theme.json formats.

Use the vault's Import-page layout for Settings: a clickable vault breadcrumb, Appearance and Security controls at the upper right, and a bordered content panel. Preserve the vault selection when returning from Settings.

Keep launch-time lease overrides authoritative and apply changed security settings on the next unlock. Pass a captured lease policy to main's separate vault worker process. Adapt the vault layout to narrow windows and scaling while retaining user window dimensions.

Validation: Linux desktop and CLI builds, 266 tests, formatting, and desktop Clippy with warnings denied passed locally. The timeout regression test verifies the worker bootstrap values. GitHub CI for the rebased revision is in progress; native Windows/macOS execution and final Settings visual verification remain pending.
