### PR TITLE
Define bundled desktop themes in TOML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,6 +2496,7 @@ dependencies = [
  "serde_json",
  "smol",
  "tempfile",
+ "toml 1.1.5+spec-1.1.0",
  "xdg",
  "zeroize",
 ]

--- a/factorseal-desktop/Cargo.toml
+++ b/factorseal-desktop/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 native-theme = "=0.5.7"
 tempfile = "3.23"
+toml = "1.1"
 smol = "2.0"
 zeroize = "1.8"
 

--- a/factorseal-desktop/src/appearance.rs
+++ b/factorseal-desktop/src/appearance.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::LazyLock};
 
 use anyhow::{Context as _, Result};
 use gpui::{App, Global, Hsla};
@@ -30,74 +30,60 @@ pub(crate) enum Choice {
     CatppuccinMacchiato,
 }
 
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Catalog {
+    themes: Vec<ThemeEntry>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ThemeEntry {
+    id: Choice,
+    label: String,
+    preset: Option<String>,
+    mode: Option<Variant>,
+}
+
+#[derive(Clone, Copy, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum Variant {
+    Light,
+    Dark,
+}
+
+static CATALOG: LazyLock<Catalog> = LazyLock::new(|| {
+    toml::from_str(include_str!("../themes/catalog.toml")).expect("invalid embedded theme catalog")
+});
+
 impl Choice {
     pub(crate) fn all() -> impl Iterator<Item = Self> {
-        [
-            Self::FactorSeal,
-            Self::System,
-            Self::GruvboxLight,
-            Self::GruvboxDark,
-            Self::OneLight,
-            Self::OneDark,
-            Self::DraculaLight,
-            Self::Dracula,
-            Self::SolarizedLight,
-            Self::SolarizedDark,
-            Self::NordLight,
-            Self::Nord,
-            Self::TokyoNightDay,
-            Self::TokyoNight,
-            Self::CatppuccinLatte,
-            Self::CatppuccinFrappe,
-            Self::CatppuccinMacchiato,
-            Self::CatppuccinMocha,
-        ]
-        .into_iter()
+        CATALOG.themes.iter().map(|entry| entry.id)
+    }
+
+    fn entry(self) -> &'static ThemeEntry {
+        CATALOG
+            .themes
+            .iter()
+            .find(|entry| entry.id == self)
+            .expect("theme missing from embedded catalog")
     }
 
     pub(crate) fn label(self) -> &'static str {
-        match self {
-            Self::FactorSeal => "FactorSeal",
-            Self::System => "System",
-            Self::GruvboxLight => "Gruvbox Light",
-            Self::GruvboxDark => "Gruvbox Dark",
-            Self::OneLight => "One Light",
-            Self::OneDark => "One Dark",
-            Self::DraculaLight => "Dracula Light",
-            Self::Dracula => "Dracula",
-            Self::SolarizedLight => "Solarized Light",
-            Self::SolarizedDark => "Solarized Dark",
-            Self::NordLight => "Nord Light",
-            Self::Nord => "Nord",
-            Self::TokyoNightDay => "Tokyo Night Day",
-            Self::TokyoNight => "Tokyo Night",
-            Self::CatppuccinLatte => "Catppuccin Latte",
-            Self::CatppuccinFrappe => "Catppuccin Frappé",
-            Self::CatppuccinMacchiato => "Catppuccin Macchiato",
-            Self::CatppuccinMocha => "Catppuccin Mocha",
-        }
+        &self.entry().label
     }
 
     fn preset(self) -> Option<(&'static str, ColorMode)> {
-        match self {
-            Self::FactorSeal | Self::System => None,
-            Self::GruvboxLight => Some(("gruvbox", ColorMode::Light)),
-            Self::GruvboxDark => Some(("gruvbox", ColorMode::Dark)),
-            Self::OneLight => Some(("one-dark", ColorMode::Light)),
-            Self::OneDark => Some(("one-dark", ColorMode::Dark)),
-            Self::DraculaLight => Some(("dracula", ColorMode::Light)),
-            Self::Dracula => Some(("dracula", ColorMode::Dark)),
-            Self::SolarizedLight => Some(("solarized", ColorMode::Light)),
-            Self::SolarizedDark => Some(("solarized", ColorMode::Dark)),
-            Self::NordLight => Some(("nord", ColorMode::Light)),
-            Self::Nord => Some(("nord", ColorMode::Dark)),
-            Self::TokyoNightDay => Some(("tokyo-night", ColorMode::Light)),
-            Self::TokyoNight => Some(("tokyo-night", ColorMode::Dark)),
-            Self::CatppuccinLatte => Some(("catppuccin-latte", ColorMode::Light)),
-            Self::CatppuccinFrappe => Some(("catppuccin-frappe", ColorMode::Dark)),
-            Self::CatppuccinMacchiato => Some(("catppuccin-macchiato", ColorMode::Dark)),
-            Self::CatppuccinMocha => Some(("catppuccin-mocha", ColorMode::Dark)),
-        }
+        let entry = self.entry();
+        entry.preset.as_deref().zip(entry.mode).map(|(name, mode)| {
+            (
+                name,
+                match mode {
+                    Variant::Light => ColorMode::Light,
+                    Variant::Dark => ColorMode::Dark,
+                },
+            )
+        })
     }
 }
 
@@ -246,6 +232,40 @@ pub(crate) fn system_changed(cx: &mut App) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn embedded_catalog_preserves_theme_ids_and_valid_sources() {
+        let expected = [
+            "factorseal",
+            "system",
+            "gruvbox-light",
+            "gruvbox-dark",
+            "one-light",
+            "one-dark",
+            "dracula-light",
+            "dracula",
+            "solarized-light",
+            "solarized-dark",
+            "nord-light",
+            "nord",
+            "tokyo-night-day",
+            "tokyo-night",
+            "catppuccin-latte",
+            "catppuccin-frappe",
+            "catppuccin-macchiato",
+            "catppuccin-mocha",
+        ];
+        let ids: Vec<_> = Choice::all()
+            .map(|choice| serde_json::to_value(choice).unwrap())
+            .collect();
+        assert_eq!(ids, expected.map(serde_json::Value::from));
+        for entry in &CATALOG.themes {
+            assert!(!entry.label.trim().is_empty());
+            let builtin = matches!(entry.id, Choice::FactorSeal | Choice::System);
+            assert_eq!(entry.preset.is_none(), builtin);
+            assert_eq!(entry.mode.is_none(), builtin);
+        }
+    }
 
     #[test]
     fn additional_bundled_variants_have_distinct_palettes() {

--- a/factorseal-desktop/src/branding.rs
+++ b/factorseal-desktop/src/branding.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use gpui::{Hsla, px, rgb};
 use gpui_component::{scroll::ScrollbarMode, theme::Theme};
 
@@ -7,7 +9,8 @@ pub(crate) const SEARCH_ASSET: &str = "factorseal-search.svg";
 pub(crate) const CLOSE_ASSET: &str = "factorseal-close.svg";
 pub(crate) const TAGLINE: &str = "Your secrets stay here.";
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 struct Palette {
     canvas: u32,
     surface: u32,
@@ -20,35 +23,32 @@ struct Palette {
     selection: u32,
     success: u32,
     danger: u32,
+    primary_hover: u32,
+    primary_active: u32,
 }
 
-const DARK: Palette = Palette {
-    canvas: 0x0015_1515,
-    surface: 0x001d_1d1b,
-    raised: 0x0024_2421,
-    ink: 0x00f7_f3ea,
-    quiet: 0x00b9_b5ac,
-    border: 0x003b_3934,
-    secondary: 0x0029_2825,
-    secondary_hover: 0x0034_322e,
-    selection: 0x003c_3933,
-    success: 0x0081_c995,
-    danger: 0x00f2_8b82,
-};
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Definition {
+    dark: Palette,
+    light: Palette,
+    warning: u32,
+    overlay: u32,
+    overlay_opacity: f32,
+    scrollbar_opacity: f32,
+    scrollbar_thumb_opacity: f32,
+    scrollbar_thumb_hover_opacity: f32,
+    radius: f32,
+    radius_lg: f32,
+    tile_radius: f32,
+    shadow: bool,
+    tile_shadow: bool,
+}
 
-const LIGHT: Palette = Palette {
-    canvas: 0x00f7_f3ea,
-    surface: 0x00ff_fcf6,
-    raised: 0x00ef_eae1,
-    ink: 0x0015_1515,
-    quiet: 0x0068_635b,
-    border: 0x00d9_d2c7,
-    secondary: 0x00e9_e3d9,
-    secondary_hover: 0x00dd_d6ca,
-    selection: 0x00d7_d0c5,
-    success: 0x002f_6b4f,
-    danger: 0x00a3_3d32,
-};
+static DEFINITION: LazyLock<Definition> = LazyLock::new(|| {
+    toml::from_str(include_str!("../themes/factorseal.toml"))
+        .expect("invalid embedded FactorSeal theme")
+});
 
 fn color(hex: u32) -> Hsla {
     rgb(hex).into()
@@ -60,8 +60,12 @@ fn color(hex: u32) -> Hsla {
 /// visual tokens so the application remains recognizably `FactorSeal` on every
 /// desktop environment.
 pub(crate) fn apply(theme: &mut Theme) {
-    let dark = theme.is_dark();
-    let palette = if dark { DARK } else { LIGHT };
+    let definition = &*DEFINITION;
+    let palette = if theme.is_dark() {
+        definition.dark
+    } else {
+        definition.light
+    };
     let Palette {
         canvas,
         surface,
@@ -74,6 +78,8 @@ pub(crate) fn apply(theme: &mut Theme) {
         selection,
         success,
         danger,
+        primary_hover,
+        primary_active,
     } = palette;
 
     theme.background = color(canvas);
@@ -93,16 +99,8 @@ pub(crate) fn apply(theme: &mut Theme) {
 
     theme.primary = color(ink);
     theme.primary_foreground = color(canvas);
-    theme.primary_hover = if dark {
-        color(0x00e8_e3da)
-    } else {
-        color(0x002b_2b29)
-    };
-    theme.primary_active = if dark {
-        color(0x00d8_d2c8)
-    } else {
-        color(0x0000_0000)
-    };
+    theme.primary_hover = color(primary_hover);
+    theme.primary_active = color(primary_active);
 
     theme.accent = color(secondary_hover);
     theme.accent_foreground = color(ink);
@@ -122,9 +120,9 @@ pub(crate) fn apply(theme: &mut Theme) {
     theme.sidebar_border = color(border);
     theme.sidebar_primary = color(ink);
     theme.scrollbar_mode = ScrollbarMode::Always;
-    theme.scrollbar = color(canvas).opacity(0.0);
-    theme.scrollbar_thumb = color(quiet).opacity(0.32);
-    theme.scrollbar_thumb_hover = color(quiet).opacity(0.56);
+    theme.scrollbar = color(canvas).opacity(definition.scrollbar_opacity);
+    theme.scrollbar_thumb = color(quiet).opacity(definition.scrollbar_thumb_opacity);
+    theme.scrollbar_thumb_hover = color(quiet).opacity(definition.scrollbar_thumb_hover_opacity);
     theme.sidebar_primary_foreground = color(canvas);
 
     theme.link = color(ink);
@@ -138,7 +136,7 @@ pub(crate) fn apply(theme: &mut Theme) {
     theme.danger_foreground = color(canvas);
     theme.danger_hover = color(danger);
     theme.danger_active = color(danger);
-    theme.warning = color(0x00a1_5c22);
+    theme.warning = color(definition.warning);
     theme.warning_foreground = color(canvas);
     theme.info = color(ink);
     theme.info_foreground = color(canvas);
@@ -147,11 +145,39 @@ pub(crate) fn apply(theme: &mut Theme) {
     theme.title_bar = color(canvas);
     theme.title_bar_border = color(border);
     theme.window_border = color(border);
-    theme.overlay = color(0x0015_1515).opacity(0.56);
+    theme.overlay = color(definition.overlay).opacity(definition.overlay_opacity);
 
-    theme.radius = px(7.);
-    theme.radius_lg = px(12.);
-    theme.shadow = false;
-    theme.tile_shadow = false;
-    theme.tile_radius = px(12.);
+    theme.radius = px(definition.radius);
+    theme.radius_lg = px(definition.radius_lg);
+    theme.shadow = definition.shadow;
+    theme.tile_shadow = definition.tile_shadow;
+    theme.tile_radius = px(definition.tile_radius);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui_component::theme::ThemeMode;
+
+    #[test]
+    fn embedded_palette_preserves_brand_colors_and_system_typography() {
+        for (mode, background, foreground, hover) in [
+            (ThemeMode::Light, 0x00f7_f3ea, 0x0015_1515, 0x002b_2b29),
+            (ThemeMode::Dark, 0x0015_1515, 0x00f7_f3ea, 0x00e8_e3da),
+        ] {
+            let mut theme = Theme {
+                mode,
+                font_family: "Test font".into(),
+                font_size: px(19.),
+                ..Theme::default()
+            };
+            apply(&mut theme);
+            assert_eq!(theme.mode, mode);
+            assert_eq!(theme.background, color(background));
+            assert_eq!(theme.foreground, color(foreground));
+            assert_eq!(theme.primary_hover, color(hover));
+            assert_eq!(theme.font_family.as_ref(), "Test font");
+            assert_eq!(theme.font_size, px(19.));
+        }
+    }
 }

--- a/factorseal-desktop/themes/catalog.toml
+++ b/factorseal-desktop/themes/catalog.toml
@@ -1,0 +1,103 @@
+[[themes]]
+id = "factorseal"
+label = "FactorSeal"
+
+[[themes]]
+id = "system"
+label = "System"
+
+[[themes]]
+id = "gruvbox-light"
+label = "Gruvbox Light"
+preset = "gruvbox"
+mode = "light"
+
+[[themes]]
+id = "gruvbox-dark"
+label = "Gruvbox Dark"
+preset = "gruvbox"
+mode = "dark"
+
+[[themes]]
+id = "one-light"
+label = "One Light"
+preset = "one-dark"
+mode = "light"
+
+[[themes]]
+id = "one-dark"
+label = "One Dark"
+preset = "one-dark"
+mode = "dark"
+
+[[themes]]
+id = "dracula-light"
+label = "Dracula Light"
+preset = "dracula"
+mode = "light"
+
+[[themes]]
+id = "dracula"
+label = "Dracula"
+preset = "dracula"
+mode = "dark"
+
+[[themes]]
+id = "solarized-light"
+label = "Solarized Light"
+preset = "solarized"
+mode = "light"
+
+[[themes]]
+id = "solarized-dark"
+label = "Solarized Dark"
+preset = "solarized"
+mode = "dark"
+
+[[themes]]
+id = "nord-light"
+label = "Nord Light"
+preset = "nord"
+mode = "light"
+
+[[themes]]
+id = "nord"
+label = "Nord"
+preset = "nord"
+mode = "dark"
+
+[[themes]]
+id = "tokyo-night-day"
+label = "Tokyo Night Day"
+preset = "tokyo-night"
+mode = "light"
+
+[[themes]]
+id = "tokyo-night"
+label = "Tokyo Night"
+preset = "tokyo-night"
+mode = "dark"
+
+[[themes]]
+id = "catppuccin-latte"
+label = "Catppuccin Latte"
+preset = "catppuccin-latte"
+mode = "light"
+
+[[themes]]
+id = "catppuccin-frappe"
+label = "Catppuccin Frappé"
+preset = "catppuccin-frappe"
+mode = "dark"
+
+[[themes]]
+id = "catppuccin-macchiato"
+label = "Catppuccin Macchiato"
+preset = "catppuccin-macchiato"
+mode = "dark"
+
+[[themes]]
+id = "catppuccin-mocha"
+label = "Catppuccin Mocha"
+preset = "catppuccin-mocha"
+mode = "dark"

--- a/factorseal-desktop/themes/factorseal.toml
+++ b/factorseal-desktop/themes/factorseal.toml
@@ -1,0 +1,41 @@
+warning = 0xa15c22
+overlay = 0x151515
+overlay_opacity = 0.56
+scrollbar_opacity = 0.0
+scrollbar_thumb_opacity = 0.32
+scrollbar_thumb_hover_opacity = 0.56
+radius = 7.0
+radius_lg = 12.0
+tile_radius = 12.0
+shadow = false
+tile_shadow = false
+
+[dark]
+canvas = 0x151515
+surface = 0x1d1d1b
+raised = 0x242421
+ink = 0xf7f3ea
+quiet = 0xb9b5ac
+border = 0x3b3934
+secondary = 0x292825
+secondary_hover = 0x34322e
+selection = 0x3c3933
+success = 0x81c995
+danger = 0xf28b82
+primary_hover = 0xe8e3da
+primary_active = 0xd8d2c8
+
+[light]
+canvas = 0xf7f3ea
+surface = 0xfffcf6
+raised = 0xefeae1
+ink = 0x151515
+quiet = 0x68635b
+border = 0xd9d2c7
+secondary = 0xe9e3d9
+secondary_hover = 0xddd6ca
+selection = 0xd7d0c5
+success = 0x2f6b4f
+danger = 0xa33d32
+primary_hover = 0x2b2b29
+primary_active = 0x000000


### PR DESCRIPTION
Move the theme catalog and FactorSeal palette into TOML files embedded with include_str!. The catalog owns labels, order and community preset variants. Community palettes remain embedded through native-theme. Changes require a rebuild, and the application does not read theme files from disk at runtime.

This PR builds on desktop-preferences. Validation: Linux desktop tests and Clippy with warnings denied pass. Regression tests verify existing theme IDs, catalog sources, FactorSeal light/dark colors and retained system typography.
