### PR TITLE
Add tray-free desktop testing

### DIFF
--- a/factorseal-desktop/src/app.rs
+++ b/factorseal-desktop/src/app.rs
@@ -52,6 +52,7 @@ impl Global for RuntimeGlobal {}
 struct DesktopStatus {
     unsealed: bool,
     quitting: bool,
+    no_tray: bool,
 }
 
 impl Global for DesktopStatus {}
@@ -2984,6 +2985,10 @@ fn open_desktop_window(
         },
         move |window, cx| {
             window.on_window_should_close(cx, |window, cx| {
+                if cx.global::<DesktopStatus>().no_tray {
+                    quit(&Quit, cx);
+                    return true;
+                }
                 if cx.global::<DesktopStatus>().quitting {
                     return true;
                 }
@@ -3005,6 +3010,7 @@ fn open_desktop_window(
 pub(crate) fn setup(
     config: RuntimeConfig,
     background: bool,
+    no_tray: bool,
     activations: smol::channel::Receiver<()>,
     cx: &mut App,
 ) {
@@ -3022,6 +3028,7 @@ pub(crate) fn setup(
     cx.set_global(DesktopStatus {
         unsealed: matches!(initial, Snapshot::Unsealed { .. }),
         quitting: false,
+        no_tray,
     });
 
     let view_holder = Arc::new(std::sync::Mutex::new(None));
@@ -3045,7 +3052,9 @@ pub(crate) fn setup(
         desktop.handle = Some(handle);
         desktop.visible = !background;
     }
-    install_tray(cx);
+    if !no_tray {
+        install_tray(cx);
+    }
 
     let task = cx.spawn(async move |cx| {
         while let Ok(snapshot) = receiver.recv().await {

--- a/factorseal-desktop/src/main.rs
+++ b/factorseal-desktop/src/main.rs
@@ -61,6 +61,9 @@ struct Args {
     #[arg(long)]
     background: bool,
 
+    #[arg(long, hide = true, conflicts_with_all = ["background", "keyring_activation"])]
+    no_tray: bool,
+
     /// Activate Desktop for a queued Secret Service request.
     #[arg(long, hide = true)]
     keyring_activation: bool,
@@ -124,7 +127,7 @@ fn main() {
     gpui_platform::application()
         .with_assets(Assets)
         .with_quit_mode(QuitMode::Explicit)
-        .run(move |cx| app::setup(config, args.background, activations, cx));
+        .run(move |cx| app::setup(config, args.background, args.no_tray, activations, cx));
     drop(instance_lock);
 }
 
@@ -172,5 +175,17 @@ mod tests {
 
         let help = Args::command().render_long_help().to_string();
         assert!(!help.contains("keyring-activation"));
+    }
+
+    #[test]
+    fn tray_free_mode_requires_a_visible_launch() {
+        assert!(
+            Args::try_parse_from(["factorseal-desktop", "--no-tray"])
+                .unwrap()
+                .no_tray
+        );
+        for argument in ["--background", "--keyring-activation"] {
+            assert!(Args::try_parse_from(["factorseal-desktop", "--no-tray", argument]).is_err());
+        }
     }
 }


### PR DESCRIPTION
Add a hidden --no-tray option for foreground desktop testing. It skips tray installation and quits the application when its window closes. Reject combinations with --background and --keyring-activation.

Validation: Linux desktop tests and Clippy with warnings denied pass, including accepted and conflicting CLI combinations. Interactive window-close behavior still needs a manual check.
