### PR TITLE
Take over the Secret Service name and fail activation loudly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,3 +165,10 @@ the schema version advances. Unknown formats are rejected and never deleted.
   value. Path arguments complete files and directories, and internal commands
   stay hidden. Completion answers from the command definition alone: it never
   resolves a vault root, reads vault metadata, or contacts the service.
+- Keep the Secret Service name under FactorSeal's control on Linux: when
+  another provider still owns `org.freedesktop.secrets` at unseal, the vault
+  now takes the name over as soon as that provider releases it or crashes,
+  instead of giving up for the rest of the session. The desktop keyring
+  activation helper exits with a failure when the Desktop does not publish the
+  name in time, so dbus-broker fails waiting clients instead of queuing them
+  forever.

--- a/factorseal-desktop/src/main.rs
+++ b/factorseal-desktop/src/main.rs
@@ -140,6 +140,11 @@ fn main() {
             && let Err(error) = wait_for_secret_service(ACTIVATION_WAIT)
         {
             eprintln!("factorseal-desktop: {error}");
+            // D-Bus activation launched this process to make the Secret Service
+            // name appear. dbus-broker keeps every caller queued until the name is
+            // owned or the activated unit fails, so exiting cleanly here would
+            // leave those callers hanging indefinitely.
+            std::process::exit(1);
         }
         return;
     }

--- a/src/vault/secret_service.rs
+++ b/src/vault/secret_service.rs
@@ -38,6 +38,7 @@ const DEFAULT_ALIAS_PATH: &str = "/org/freedesktop/secrets/aliases/default";
 const ITEM_PREFIX: &str = "/org/freedesktop/secrets/collection/factorseal/";
 const SESSION_PREFIX: &str = "/org/freedesktop/secrets/session/";
 const MAX_SESSIONS: usize = 1024;
+const TAKEOVER_POLL: Duration = Duration::from_secs(1);
 
 type Secret = (OwnedObjectPath, Vec<u8>, Vec<u8>, String);
 type Properties = HashMap<String, OwnedValue>;
@@ -80,13 +81,11 @@ pub(crate) fn serve_secret_service(
         };
         let agent = Arc::new(Agent::load(store)?);
         let connection = Connection::session().await.map_err(dbus_error)?;
-        let name_claim = connection
-            .request_name_with_flags(BUS_NAME, zbus::fdo::RequestNameFlags::DoNotQueue.into())
-            .await;
-        if !secret_service_name_claimed(name_claim)? {
-            eprintln!(
-                "FactorSeal: Secret Service integration is unavailable because {BUS_NAME} is already provided by another process"
-            );
+        let claimed = claim_secret_service_name(&connection, TAKEOVER_POLL, || {
+            Ok(stopping.load(Ordering::Acquire) || service.expire_if_needed(unix_time())?)
+        })
+        .await?;
+        if !claimed {
             return Ok(());
         }
         let server = connection.object_server();
@@ -294,6 +293,54 @@ fn secret_service_name_claimed<T>(result: Result<T, zbus::Error>) -> VaultResult
         Err(error) => Err(dbus_error(error)),
     }
 }
+/// Claim the Secret Service name, taking it over from a previous provider once
+/// that provider releases it.
+///
+/// Another Secret Service (gnome-keyring, KWallet, or a second FactorSeal
+/// instance) may still own `org.freedesktop.secrets` when the vault unseals.
+/// Giving up at that point left the name unowned for the rest of this process
+/// once the other provider exited or crashed, while the desktop activation
+/// helper kept waiting on this process to publish it. Returns `false` when
+/// `should_stop` reports that the vault sealed or the service is stopping
+/// before the name became available.
+async fn claim_secret_service_name(
+    connection: &Connection,
+    poll: Duration,
+    mut should_stop: impl FnMut() -> VaultResult<bool>,
+) -> VaultResult<bool> {
+    let bus = fdo::DBusProxy::new(connection).await.map_err(dbus_error)?;
+    let name = zbus::names::BusName::try_from(BUS_NAME)
+        .map_err(|error| VaultError::Protocol(format!("invalid Secret Service name: {error}")))?;
+    let mut announced = false;
+    loop {
+        let claim = connection
+            .request_name_with_flags(BUS_NAME, fdo::RequestNameFlags::DoNotQueue.into())
+            .await;
+        if secret_service_name_claimed(claim)? {
+            return Ok(true);
+        }
+        if !announced {
+            eprintln!(
+                "FactorSeal: {BUS_NAME} is currently provided by another process; FactorSeal takes over when it is released"
+            );
+            announced = true;
+        }
+        loop {
+            if should_stop()? {
+                return Ok(false);
+            }
+            tokio::time::sleep(poll).await;
+            let owned = bus
+                .name_has_owner(name.clone())
+                .await
+                .map_err(|error| dbus_error(error.into()))?;
+            if !owned {
+                break;
+            }
+        }
+    }
+}
+
 fn failed(error: impl std::fmt::Display) -> fdo::Error {
     fdo::Error::Failed(error.to_string())
 }
@@ -456,6 +503,66 @@ mod tests {
             .unwrap();
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn secret_service_name_is_taken_over_once_the_previous_owner_releases_it() {
+        // Skips outside a desktop session and when a real Secret Service owns
+        // the bus name; Linux CI runs the suite under `dbus-run-session`.
+        if std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_none() {
+            return;
+        }
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let Ok(previous_owner) = Connection::session().await else {
+                return;
+            };
+            match previous_owner
+                .request_name_with_flags(BUS_NAME, zbus::fdo::RequestNameFlags::DoNotQueue.into())
+                .await
+            {
+                Ok(_) => {}
+                Err(zbus::Error::NameTaken) => return,
+                Err(error) => panic!("could not register the Secret Service test name: {error}"),
+            }
+            let claimant = Connection::session().await.unwrap();
+            let poll = Duration::from_millis(1);
+            // Stopping while another provider still owns the name gives up.
+            let claimed = claim_secret_service_name(&claimant, poll, || Ok(true))
+                .await
+                .unwrap();
+            assert!(!claimed);
+            // Release the name only once the claimant is observed waiting for it.
+            let release = Arc::new(tokio::sync::Notify::new());
+            let releaser = {
+                let release = Arc::clone(&release);
+                let previous_owner = previous_owner.clone();
+                tokio::spawn(async move {
+                    release.notified().await;
+                    assert!(previous_owner.release_name(BUS_NAME).await.unwrap());
+                })
+            };
+            let claimed = claim_secret_service_name(&claimant, poll, || {
+                release.notify_one();
+                Ok(false)
+            })
+            .await
+            .unwrap();
+            assert!(claimed);
+            releaser.await.unwrap();
+            let bus = fdo::DBusProxy::new(&claimant).await.unwrap();
+            let owner = bus
+                .get_name_owner(zbus::names::BusName::try_from(BUS_NAME).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(
+                owner.to_string(),
+                claimant.unique_name().unwrap().to_string()
+            );
+        });
+    }
     #[cfg(target_os = "linux")]
     #[test]
     #[allow(clippy::too_many_lines)]


### PR DESCRIPTION
## Problem

When the vault unseals while another provider owns `org.freedesktop.secrets` (gnome-keyring from a previous NixOS generation, in the case that prompted this), the Secret Service thread prints a notice and returns. FactorSeal then never claims the name for the rest of the session.

Once that provider goes away (gnome-keyring crashed with SIGABRT), the name stays unowned. D-Bus activation launches `factorseal-desktop --keyring-activation`, which finds the running Desktop, waits 30 seconds for it to publish a name it will never publish, prints `timed out waiting for Desktop to unseal the keyring`, and exits 0.

dbus-broker only fails queued callers when the activated unit fails. A clean exit leaves every client that touches the Secret Service blocked indefinitely. On my machine that was every running codex session, which reads its MCP OAuth credential store from the keyring at the start of each turn, hung for three hours with no error anywhere.

## Fix

* `src/vault/secret_service.rs`: while another provider owns the name, keep polling `NameHasOwner` once a second and claim the name as soon as it is released, until the vault seals or the service stops. The vault takes over from a crashed or exited provider instead of giving up for the session.
* `factorseal-desktop/src/main.rs`: the `--keyring-activation` helper exits with status 1 when the Desktop does not publish the name within the activation window, so dbus-broker fails waiting clients instead of queuing them forever.

## Verification

* Throwaway D-Bus service files on a live dbus-broker 37 session: an activated helper that exits 0 without owning the name leaves a `Ping` caller hanging past a 20 second timeout, a helper that exits 1 fails the caller within a second with `Could not activate remote peer: unit failed`.
* New test `secret_service_name_is_taken_over_once_the_previous_owner_releases_it` runs on an isolated bus. A second connection holds the name, the claimant's own poll callback wakes a task that releases it, and the test asserts the claimant ends up as the owner. It also asserts that a stop request while the name is held elsewhere gives up without the name. No timing dependence.
* `cargo clippy -D warnings` clean for `factorseal` (all features, all targets) and `factorseal-desktop`. The five Secret Service tests pass under `dbus-run-session`.

## Follow ups not in this PR

* Claim the name while sealed and answer with locked collections, the way gnome-keyring does, so a sealed or absent Desktop does not mean no Secret Service at all.
* Start the Desktop from the NixOS module on `nixos-rebuild switch`, so a generation that swaps the provider does not leave the session without one until the next login.

---

Created with Claude Code. See https://github.com/cli/cli/issues/13904 for surfacing this through the GitHub API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3uASz1HgejguErQnn15Wg
